### PR TITLE
Refine asset browsing and editor workflows

### DIFF
--- a/backend/implicit_markers.py
+++ b/backend/implicit_markers.py
@@ -110,25 +110,27 @@ async def implicit_markers_by_media(
     return result
 
 
-def latest_direct_edit_at(asset_id_column):
-    """Latest direct editor Revision timestamp for an Asset.
+def latest_edited_revision_at(asset_id_column):
+    """Latest Revision timestamp that satisfies the edited-marker criteria.
 
-    Descendants that merely inherit image-editor lineage have no direct edit
-    event on their own Asset. Browser sorting deliberately lets those fall back
-    to the current payload's import date.
+    The marker is lineage-based, so the sort timestamp must be lineage-based as
+    well. This keeps inherited editor provenance and direct editor output under
+    the same definition instead of independently consulting ``MediaItem.tool_id``.
     """
     revision = aliased(AssetRevision)
     media = aliased(MediaItem)
+    tool_lineage = aliased(MediaToolLineage)
     return (
         select(func.max(revision.created_at))
         .select_from(revision)
         .join(media, media.id == revision.primary_media_id)
+        .join(tool_lineage, tool_lineage.media_id == media.id)
         .where(
             revision.asset_id == asset_id_column,
             revision.deleted_at.is_(None),
             media.deleted_at.is_(None),
-            media.tool_id.in_(EDITED_TOOL_IDS),
+            tool_lineage.full_tool_id.in_(EDITED_TOOL_IDS),
         )
-        .correlate_except(revision, media)
+        .correlate_except(revision, media, tool_lineage)
         .scalar_subquery()
     )

--- a/backend/routes/assets.py
+++ b/backend/routes/assets.py
@@ -49,9 +49,8 @@ from tool_display import resolve_tool_display_metadata
 from implicit_markers import (
     EDITED_MARKER,
     EDITED_MARKER_KEY,
-    EDITED_TOOL_IDS,
     implicit_markers_by_media,
-    latest_direct_edit_at,
+    latest_edited_revision_at,
     media_has_implicit_marker,
 )
 from core.dependencies import get_db_session
@@ -257,11 +256,17 @@ def _apply_asset_browser_sort(query, sort_by: str, random_seed: int | None):
     if sort_by == "indexed_asc":
         return query.order_by(MediaItem.indexed_date.asc(), Asset.id.asc())
     if sort_by == "edited_desc":
-        # Direct editor revisions carry the true edit time. Assets that only
-        # inherit editor lineage, plus wholly unedited Assets, fall back to the
-        # same timestamp used by Recently imported.
+        # Classification must exactly match the marker shown on the current
+        # browser item. Marked Assets sort by their latest marker-bearing
+        # revision; everything else uses the Recently imported timestamp.
         edit_or_import_at = func.coalesce(
-            latest_direct_edit_at(Asset.id), MediaItem.indexed_date
+            case(
+                (
+                    media_has_implicit_marker(EDITED_MARKER_KEY, MediaItem.id),
+                    latest_edited_revision_at(Asset.id),
+                )
+            ),
+            MediaItem.indexed_date,
         )
         return query.order_by(edit_or_import_at.desc(), Asset.id.desc())
     if sort_by == "deleted_desc":
@@ -497,21 +502,24 @@ async def browse_assets(
                 reverse=True,
             )
         elif sort_by == "edited_desc":
-            asset_ids = [row[0].id for row in rows]
-            edit_rows = (
-                await session.execute(
-                    select(AssetRevision.asset_id, func.max(AssetRevision.created_at))
-                    .join(MediaItem, MediaItem.id == AssetRevision.primary_media_id)
-                    .where(
-                        AssetRevision.asset_id.in_(asset_ids),
-                        AssetRevision.deleted_at.is_(None),
-                        MediaItem.deleted_at.is_(None),
-                        MediaItem.tool_id.in_(EDITED_TOOL_IDS),
-                    )
-                    .group_by(AssetRevision.asset_id)
+            markers_by_media = await implicit_markers_by_media(
+                session, [row[2].id for row in rows]
+            )
+            edited_asset_ids = [
+                row[0].id for row in rows if markers_by_media[row[2].id]
+            ]
+            edited_at = {}
+            if edited_asset_ids:
+                edited_at = dict(
+                    (
+                        await session.execute(
+                            select(
+                                Asset.id,
+                                latest_edited_revision_at(Asset.id),
+                            ).where(Asset.id.in_(edited_asset_ids))
+                        )
+                    ).all()
                 )
-            ).all()
-            edited_at = dict(edit_rows)
             rows.sort(
                 key=lambda row: edited_at.get(row[0].id) or row[2].indexed_date,
                 reverse=True,

--- a/backend/tests/test_assets_api.py
+++ b/backend/tests/test_assets_api.py
@@ -20,6 +20,7 @@ from asset_service import (
 from database import (
     Asset,
     AssetMarker,
+    AssetRevision,
     AssetSnapshot,
     AssetTag,
     Chat,
@@ -1171,11 +1172,52 @@ async def test_recently_edited_sort_uses_edit_date_then_import_fallback(
             )
         )
 
+        inherited_edit_source = await create_media_item(session)
+        inherited_edit_asset = await create_asset_from_media(
+            session, media_id=inherited_edit_source.id
+        )
+        inherited_edit = await create_media_item(
+            session,
+            vlm_caption=caption,
+            tool_id="test:post-edit-transform",
+        )
+        inherited_edit.indexed_date = datetime(2025, 1, 1)
+        inherited_edit_revision = await commit_revision(
+            session, asset_id=inherited_edit_asset.id, media_id=inherited_edit.id
+        )
+        inherited_edit_revision.created_at = datetime(2025, 1, 5)
+        session.add(
+            MediaToolLineage(
+                media_id=inherited_edit.id,
+                full_tool_id=IMAGE_EDITOR_TOOL_ID,
+            )
+        )
+
+        unmarked_editor_output = await create_media_item(
+            session,
+            vlm_caption=caption,
+            tool_id=IMAGE_EDITOR_TOOL_ID,
+        )
+        unmarked_editor_output.indexed_date = datetime(2025, 1, 2)
+        unmarked_editor_asset = await create_asset_from_media(
+            session, media_id=unmarked_editor_output.id
+        )
+        unmarked_editor_revision = await session.get(
+            AssetRevision, unmarked_editor_asset.current_revision_id
+        )
+        unmarked_editor_revision.created_at = datetime(2025, 1, 6)
+
         plain = await create_media_item(session, vlm_caption=caption)
         plain.indexed_date = datetime(2025, 1, 4)
         plain_asset = await create_asset_from_media(session, media_id=plain.id)
         await session.commit()
-        expected = [plain_asset.id, edited_two_asset.id, edited_one_asset.id]
+        expected = [
+            inherited_edit_asset.id,
+            plain_asset.id,
+            edited_two_asset.id,
+            unmarked_editor_asset.id,
+            edited_one_asset.id,
+        ]
 
     response = await client.get(
         "/api/assets/browse",
@@ -1183,6 +1225,11 @@ async def test_recently_edited_sort_uses_edit_date_then_import_fallback(
     )
     assert response.status_code == 200, response.text
     assert [item["asset_id"] for item in response.json()["items"]] == expected
+    items = {item["asset_id"]: item for item in response.json()["items"]}
+    assert [marker["id"] for marker in items[inherited_edit_asset.id]["markers"]] == [
+        EDITED_MARKER_ID
+    ]
+    assert items[unmarked_editor_asset.id]["markers"] == []
 
     ids = await client.get(
         "/api/assets/browse/ids",

--- a/frontend/src/components/EditorShelf.vue
+++ b/frontend/src/components/EditorShelf.vue
@@ -149,8 +149,8 @@ onBeforeUnmount(() => observer?.disconnect())
 
 const capacity = computed(() => shelfColumns(shelfWidth.value) * SHELF_ROWS)
 const split = computed(() => splitShelf(ranked.value, capacity.value))
-// Membership from rank, position from when it was opened — so activating a
-// chip never makes the shelf rearrange under the cursor.
+// Membership comes from rank; position is newest-opened first. Activating an
+// existing chip therefore never makes the shelf rearrange under the cursor.
 const visible = computed(() => orderForDisplay(split.value.visible))
 const overflow = computed(() => split.value.overflow)
 

--- a/frontend/src/imageEditor/stack/adjustmentParity.test.ts
+++ b/frontend/src/imageEditor/stack/adjustmentParity.test.ts
@@ -6,7 +6,10 @@ import {
   maskedRetouchAdjustmentParams,
   wholeImageAdjustmentParams,
 } from './adjustSections.ts'
-import { buildLiveAdjustUniforms } from './liveAdjustPreview.ts'
+import {
+  buildLiveAdjustUniforms,
+  maskedAdjustmentNeedsCompositorPreview,
+} from './liveAdjustPreview.ts'
 
 function changedValue(control: (typeof PHOTO_ADJUSTMENT_CONTROLS)[number]) {
   if (control.kind === 'curve') {
@@ -84,6 +87,13 @@ test('the GPU drag preview covers exactly the controls not marked commit-only', 
       )
     }
   }
+})
+
+test('masked blur uses the authoritative compositor preview path', () => {
+  assert.equal(maskedAdjustmentNeedsCompositorPreview({ blur: 12 }), true)
+  assert.equal(maskedAdjustmentNeedsCompositorPreview({ opacity: 0.5 }), true)
+  assert.equal(maskedAdjustmentNeedsCompositorPreview({ feather_px: 8 }), true)
+  assert.equal(maskedAdjustmentNeedsCompositorPreview({ exposure: 12 }), false)
 })
 
 test('documents saved before advanced detail controls retain compatibility defaults', () => {

--- a/frontend/src/imageEditor/stack/liveAdjustPreview.ts
+++ b/frontend/src/imageEditor/stack/liveAdjustPreview.ts
@@ -21,6 +21,18 @@ import {
 
 export type AdjustmentValues = Record<string, any>
 
+/**
+ * Masked blur cannot use the GPU delta approximation without changing scope
+ * semantics: the shader samples across the whole viewport before its final
+ * mask mix, while the authoritative renderer composites an adjusted region.
+ * Route spatial blur drags through the scaled document compositor instead.
+ */
+export function maskedAdjustmentNeedsCompositorPreview(
+  patch: Record<string, unknown>,
+): boolean {
+  return 'opacity' in patch || 'feather_px' in patch || 'blur' in patch
+}
+
 const VERTEX_SHADER = `
 attribute vec2 a_position;
 varying vec2 v_uv;

--- a/frontend/src/imageEditor/stack/repaintSession.test.ts
+++ b/frontend/src/imageEditor/stack/repaintSession.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { reusableRepaintOp } from './repaintSession.ts'
+import type { StackDocument } from './types.ts'
+
+function repaint(id = 'repaint') {
+  return {
+    id,
+    class: 'patch',
+    enabled: true,
+    label: 'Regenerate',
+    exec: { kind: 'tool', tool_id: 'provider:inpaint', task_type: 'inpaint-image' },
+    operation: 'repaint',
+    params: { prompt: 'first prompt' },
+    picked: 'candidate-1',
+    candidates: [],
+  }
+}
+
+function doc(edits: any[]): StackDocument {
+  return {
+    format: 'stimma-image-stack',
+    version: 1,
+    base: {
+      asset_id: 1,
+      revision_id: 1,
+      media_id: 1,
+      file_hash: 'base',
+      width: 100,
+      height: 100,
+    },
+    canvas: { width: 100, height: 100 },
+    edits,
+  } as StackDocument
+}
+
+test('an unchanged selection reuses the head Regenerate step', () => {
+  const op = repaint()
+  assert.equal(
+    reusableRepaintOp(
+      doc([op]),
+      { opId: op.id, selectionRevision: 3 },
+      3,
+      'provider:inpaint',
+      'inpaint-image',
+    ),
+    op,
+  )
+})
+
+test('clearing or changing the selection breaks the Regenerate session', () => {
+  const op = repaint()
+  assert.equal(
+    reusableRepaintOp(
+      doc([op]),
+      { opId: op.id, selectionRevision: 3 },
+      4,
+      'provider:inpaint',
+      'inpaint-image',
+    ),
+    null,
+  )
+})
+
+test('a later edit above Regenerate prevents reuse', () => {
+  const op = repaint()
+  const adjust = {
+    id: 'adjust', class: 'parametric', enabled: true, label: 'Light',
+    exec: { kind: 'adjust' }, params: { exposure: 1 },
+  }
+  assert.equal(
+    reusableRepaintOp(
+      doc([op, adjust]),
+      { opId: op.id, selectionRevision: 3 },
+      3,
+      'provider:inpaint',
+      'inpaint-image',
+    ),
+    null,
+  )
+})
+
+test('a disabled Regenerate step is not a live session target', () => {
+  const op = { ...repaint(), enabled: false }
+  assert.equal(
+    reusableRepaintOp(
+      doc([op]),
+      { opId: op.id, selectionRevision: 3 },
+      3,
+      'provider:inpaint',
+      'inpaint-image',
+    ),
+    null,
+  )
+})
+
+test('changing the model route starts a new Regenerate step', () => {
+  const op = repaint()
+  const session = { opId: op.id, selectionRevision: 3 }
+  assert.equal(
+    reusableRepaintOp(doc([op]), session, 3, 'provider:other', 'inpaint-image'),
+    null,
+  )
+  assert.equal(
+    reusableRepaintOp(doc([op]), session, 3, 'provider:inpaint', 'erase-image'),
+    null,
+  )
+})

--- a/frontend/src/imageEditor/stack/repaintSession.ts
+++ b/frontend/src/imageEditor/stack/repaintSession.ts
@@ -1,0 +1,39 @@
+import type { GenerativeOp, StackDocument } from './types.ts'
+
+export interface RepaintSession {
+  opId: string
+  selectionRevision: number
+}
+
+/**
+ * Resolve the Regenerate step that another Run may append candidates to.
+ *
+ * Selection identity is deliberately a session revision rather than a mask
+ * comparison. Clearing and redrawing the same pixels is still a new editing
+ * decision, while a selection carried through ordinary renders is still the
+ * same one. The step must remain the head: otherwise reusing it would move the
+ * new request underneath later edits and sample a different visual history.
+ */
+export function reusableRepaintOp(
+  doc: StackDocument,
+  session: RepaintSession | null,
+  selectionRevision: number,
+  toolId: string,
+  taskType: string,
+): GenerativeOp | null {
+  if (!session || session.selectionRevision !== selectionRevision) return null
+
+  const head = doc.edits[doc.edits.length - 1]
+  if (
+    !head
+    || head.id !== session.opId
+    || head.class !== 'patch'
+    || !head.enabled
+    || head.operation !== 'repaint'
+    || head.exec.kind !== 'tool'
+    || head.exec.tool_id !== toolId
+    || head.exec.task_type !== taskType
+  ) return null
+
+  return head
+}

--- a/frontend/src/utils/editorShelf.test.ts
+++ b/frontend/src/utils/editorShelf.test.ts
@@ -83,6 +83,7 @@ test('display order ignores activation, so clicking a chip never moves it', () =
     entry('third', { createdOrder: 3, touchedAt: 30 }),
   ]
   const before = orderForDisplay(entries).map(e => e.tabId)
+  assert.deepEqual(before, ['third', 'second', 'first'])
 
   // Activate the oldest chip: its rank jumps to the top...
   entries[0].touchedAt = 99
@@ -101,7 +102,22 @@ test('pinning is the one interaction that moves a chip', () => {
     entry('b', { createdOrder: 2 }),
     entry('c', { createdOrder: 3, pinned: true }),
   ]
-  assert.deepEqual(orderForDisplay(entries).map(e => e.tabId), ['c', 'a', 'b'])
+  assert.deepEqual(orderForDisplay(entries).map(e => e.tabId), ['c', 'b', 'a'])
+})
+
+test('a newly opened editor enters at the front of the unpinned shelf', () => {
+  const entries = [
+    entry('oldest', { createdOrder: 1 }),
+    entry('middle', { createdOrder: 2 }),
+  ]
+
+  assert.deepEqual(orderForDisplay(entries).map(e => e.tabId), ['middle', 'oldest'])
+
+  entries.push(entry('newest', { createdOrder: 3 }))
+  assert.deepEqual(
+    orderForDisplay(entries).map(e => e.tabId),
+    ['newest', 'middle', 'oldest'],
+  )
 })
 
 test('the flyout is plain recency order, newest first', () => {

--- a/frontend/src/utils/editorShelf.ts
+++ b/frontend/src/utils/editorShelf.ts
@@ -32,7 +32,7 @@ export interface ShelfEntry {
    * relative order and sorts them below anything actually touched since.
    */
   touchedAt: number
-  /** When the editor was opened. Fixes where the chip sits. */
+  /** When the editor was opened. Newer chips sit before older chips. */
   createdOrder: number
 }
 
@@ -79,15 +79,15 @@ export function splitShelf<T extends { pinned: boolean }>(
 }
 
 /**
- * Display order — separate from ranking on purpose. Chips sit where they were
- * opened, so clicking one never moves it: activation changes an entry's rank,
- * and rank only decides what's behind the +N chip. A chip moves when the shelf
- * membership actually changes, or when the user pins it. Nothing else.
+ * Display order — separate from ranking on purpose. New editors enter at the
+ * front, while clicking an existing one never moves it: activation changes an
+ * entry's rank, and rank only decides what's behind the +N chip. A chip moves
+ * when shelf membership changes, or when the user pins it. Nothing else.
  */
 export function orderForDisplay(entries: ShelfEntry[]): ShelfEntry[] {
   return [...entries].sort((a, b) => (
     Number(b.pinned) - Number(a.pinned) ||
-    a.createdOrder - b.createdOrder
+    b.createdOrder - a.createdOrder
   ))
 }
 

--- a/frontend/src/views/ImageEditorView.vue
+++ b/frontend/src/views/ImageEditorView.vue
@@ -58,6 +58,7 @@ import { useStackCandidates } from '../imageEditor/stack/useStackCandidates'
 import { StackCompositor, stackHashes, canvasToBlob } from '../imageEditor/stack/useStackCompositor'
 import {
   LiveAdjustPreview,
+  maskedAdjustmentNeedsCompositorPreview,
 } from '../imageEditor/stack/liveAdjustPreview'
 import type { AdjustmentValues } from '../imageEditor/stack/liveAdjustPreview'
 import {
@@ -88,6 +89,10 @@ import type {
 } from '../imageEditor/stack/paintEngineSettings'
 import { flattenWholeOps, hasWholeOps } from '../imageEditor/stack/flattenWholeOps'
 import { blastRadius, deriveStackState, moveTargetForGap } from '../imageEditor/stack/stackState'
+import {
+  reusableRepaintOp,
+  type RepaintSession,
+} from '../imageEditor/stack/repaintSession'
 import {
   directEditRowId,
   editRowKeyboardCommand,
@@ -432,6 +437,16 @@ const selModel = useSelection()
 const selectRef = ref<InstanceType<typeof StackSelectCanvas> | null>(null)
 /** The published mask: what consumers scope to. Kept in step with selModel. */
 const selection = ref<HTMLCanvasElement | null>(null)
+/**
+ * Identity for the live select-then-Regenerate loop.
+ *
+ * This advances only when the user publishes a different selection (including
+ * clear), not when render geometry merely reprojects the same master mask.
+ * That makes clearing the explicit boundary even if the same pixels are later
+ * selected again.
+ */
+let selectionRevision = 0
+let repaintSession: RepaintSession | null = null
 const armedSelectTool = ref<SelectToolId | null>(null)
 const lastSelectTool = ref<SelectToolId>(
   (rememberedIfValid(
@@ -2262,6 +2277,7 @@ async function run() {
 
   busy.value = true
   error.value = null
+  let reusedRepaintOpId: string | null = null
   try {
     const action = sub.value === 'remove'
       ? 'remove'
@@ -2294,26 +2310,44 @@ async function run() {
     const submittedReferences = action === 'repaint'
       ? copyModelReferenceImages(referenceImages.value)
       : []
+    const submittedSelectionRevision = selectionRevision
+    let submitMask = selectionAsMask()
 
-    // The op's input is the current head composite: Phase 1 appends on top,
-    // so its input hash is the head hash.
-    const { head } = stackHashes(stack.doc.value)
-
-    const opId = newOpId()
+    // Regenerate is an iterative session while its original selection remains
+    // live and its step remains the head. Another Run appends a candidate batch
+    // to that step and samples the same composite BELOW it — never the rejected
+    // candidate currently picked by the step itself.
+    const reusableOp = action === 'repaint'
+      ? reusableRepaintOp(
+          stack.doc.value,
+          repaintSession,
+          submittedSelectionRevision,
+          toolId,
+          taskType,
+        )
+      : null
+    const reusableIndex = reusableOp
+      ? stack.doc.value.edits.length - 1
+      : -1
+    const opId = reusableOp?.id ?? newOpId()
+    reusedRepaintOpId = reusableOp?.id ?? null
+    const sampledInputHash = reusableOp
+      ? stackHashes(stack.doc.value).inputs[reusableIndex]
+      : stackHashes(stack.doc.value).head
 
     // What a tool is given is the real head composite, not the stage: the
     // stage can be holding a layer out while an overlay draws it (see
     // displayDoc), and a model must never be handed pixels the document does
-    // not have.
-    const headComposite = await compositor.render(stack.doc.value)
-
-    const submitInput = headComposite
-    let submitMask = selectionAsMask()
+    // not have. A continued Regenerate session instead renders only the ops
+    // below its existing step, keeping every candidate batch on one base.
+    const submitInput = reusableOp
+      ? await compositor.renderUpTo(stack.doc.value, reusableIndex)
+      : await compositor.render(stack.doc.value)
     // A cutout has no drawn region — its "mask" is the whole frame. It exists
     // for the patch machinery (crop bounds, resample), not the wire:
     // remove-background tools declare no mask input, so none is uploaded.
     if (action === 'cutout') {
-      submitMask = fullFrameMask(headComposite.width, headComposite.height)
+      submitMask = fullFrameMask(submitInput.width, submitInput.height)
     }
     // Expand's mask is the border ring at the GROWN size. Also never uploaded
     // (outpaint tools declare no mask input; the tool grows the canvas itself
@@ -2324,15 +2358,11 @@ async function run() {
     if (action === 'expand') {
       expandParams = expandParamsFromEdges(expandEdges.value)
       const frame = expandedFrame(
-        expandEdges.value, headComposite.width, headComposite.height,
+        expandEdges.value, submitInput.width, submitInput.height,
       )
-      submitMask = expandBorderMask(headComposite.width, headComposite.height, frame)
+      submitMask = expandBorderMask(submitInput.width, submitInput.height, frame)
     }
     if (!submitMask) throw new Error('There is nothing selected to work on.')
-
-    const maskPayloadRef = await stack.uploadPayload(
-      `${opId}-mask.png`, await canvasToBlob(submitMask)
-    )
 
     const label = action === 'remove'
       ? 'Remove object'
@@ -2342,40 +2372,65 @@ async function run() {
           ? 'Expand'
           : 'Remove background'
 
-    const authoredFrame = payloadFrame()
-    const authoredToDocument = payloadTransform()
-    const op: GenerativeOp = {
-      id: opId,
-      class: 'patch',
-      enabled: true,
-      label,
-      exec: { kind: 'tool', tool_id: toolId, task_type: taskType },
-      operation: action,
-      params: {
+    let authoredToDocument = payloadTransform()
+    if (reusableOp) {
+      authoredToDocument = payloadTransform(reusableIndex)
+      // The step's inspector and future explicit Resample use the latest
+      // settings. Existing candidates remain intact and independently
+      // selectable; only the recipe for the next batch moves forward.
+      stack.setParams(opId, {
         ...toolParams,
-        ...(expandParams ?? {}),
-        ...(submittedPrompt ? { prompt: submittedPrompt } : {}),
-      },
-      reference_images: submittedReferences,
-      mask_ref: maskPayloadRef,
-      // The mask, and the candidates generated for it, are anchored to the
-      // frame they were made in.
-      payload_to_document: authoredToDocument,
-      payload_frame: authoredFrame,
-      // A cutout matte is already soft where the model made it soft; a default
-      // feather would eat the subject's edge. Expand's overdraw of the
-      // original fades into the candidate over this feather (expanded edges
-      // only) — model border content is often softer than the source, and a
-      // hard crisp-against-soft boundary reads as a seam. Tunable in Blend.
-      blend: {
-        feather_px: action === 'cutout' ? 0 : action === 'expand' ? 24 : 6,
-        opacity: 1,
-      },
-      picked: null,
-      candidates: [],
+        prompt: submittedPrompt,
+      })
+      stack.setReferenceImages(opId, submittedReferences)
+      selectedOpId.value = opId
+      // The first result from the new row replaces the disliked current pick;
+      // every older pick stays available in its original candidate row.
+      resampledOpIds.value = new Set(resampledOpIds.value).add(opId)
+    } else {
+      const maskPayloadRef = await stack.uploadPayload(
+        `${opId}-mask.png`, await canvasToBlob(submitMask)
+      )
+      const authoredFrame = payloadFrame()
+      const op: GenerativeOp = {
+        id: opId,
+        class: 'patch',
+        enabled: true,
+        label,
+        exec: { kind: 'tool', tool_id: toolId, task_type: taskType },
+        operation: action,
+        params: {
+          ...toolParams,
+          ...(expandParams ?? {}),
+          ...(submittedPrompt ? { prompt: submittedPrompt } : {}),
+        },
+        reference_images: submittedReferences,
+        mask_ref: maskPayloadRef,
+        // The mask, and the candidates generated for it, are anchored to the
+        // frame they were made in.
+        payload_to_document: authoredToDocument,
+        payload_frame: authoredFrame,
+        // A cutout matte is already soft where the model made it soft; a default
+        // feather would eat the subject's edge. Expand's overdraw of the
+        // original fades into the candidate over this feather (expanded edges
+        // only) — model border content is often softer than the source, and a
+        // hard crisp-against-soft boundary reads as a seam. Tunable in Blend.
+        blend: {
+          feather_px: action === 'cutout' ? 0 : action === 'expand' ? 24 : 6,
+          opacity: 1,
+        },
+        picked: null,
+        candidates: [],
+      }
+      stack.addOp(op)
+      selectedOpId.value = opId
+      if (
+        action === 'repaint'
+        && selectionRevision === submittedSelectionRevision
+      ) {
+        repaintSession = { opId, selectionRevision: submittedSelectionRevision }
+      }
     }
-    stack.addOp(op)
-    selectedOpId.value = opId
 
     // Cut the naming crop HERE, while the mask and the composite it was sampled
     // against are still this step's. The request itself is fire-and-forget: a
@@ -2400,7 +2455,7 @@ async function run() {
       count: action === 'cutout' ? 1 : candidateCount.value,
       params: { ...toolParams, ...(expandParams ?? {}) },
       referenceImages: submittedReferences,
-      sampledInputHash: head,
+      sampledInputHash,
       // Expand's candidate is the whole grown frame; the compositor's expand
       // branch places it by the percent math, not by an anchored transform.
       payloadToDocument: action === 'expand' ? undefined : authoredToDocument,
@@ -2424,6 +2479,11 @@ async function run() {
     // judge the result, revise the prompt or settings, and run the same region
     // again without rebuilding the selection.
   } catch (err: any) {
+    if (reusedRepaintOpId) {
+      const next = new Set(resampledOpIds.value)
+      next.delete(reusedRepaintOpId)
+      resampledOpIds.value = next
+    }
     error.value = apiErrorMessage(err, 'Could not start the edit.')
   } finally {
     busy.value = false
@@ -4845,9 +4905,9 @@ function resetRetouchSession() {
 }
 
 /**
- * Blend and mask drags render the document at fitted display resolution.
- * Masked photographic adjustments use the GPU delta preview above instead;
- * expensive source pixels are touched only once on pointer-up.
+ * Blend, mask, and spatial blur drags render the document at fitted display
+ * resolution. Other masked photographic adjustments use the GPU delta preview
+ * above; expensive source pixels are touched only once on pointer-up.
  */
 let retouchPreviewFrame: number | null = null
 let retouchPreviewInFlight = false
@@ -4983,8 +5043,12 @@ function setRetouchRegionSettings(
     coalesceKey,
   )
   const updated = retouchRegionLocation(location.region.id)?.region.settings
-  const changesMaskBlend = 'opacity' in patch || 'feather_px' in patch
-  if (updated && isMaskedAdjustmentKind(location.region.kind) && !changesMaskBlend) {
+  const needsCompositorPreview = maskedAdjustmentNeedsCompositorPreview(patch)
+  if (
+    updated
+    && isMaskedAdjustmentKind(location.region.kind)
+    && !needsCompositorPreview
+  ) {
     void previewAdjustment(
       `retouch:${location.region.id}`,
       before,
@@ -5405,7 +5469,13 @@ function clearSelection() {
   // straight at the model when crop has the display box (overlay unmounted) —
   // otherwise the ants would come back the moment crop closes.
   if (selectRef.value) selectRef.value.clear()
-  else selModel.clearSelection()
+  else {
+    selModel.clearSelection()
+    // With no overlay there is no published `change`, but clear is still the
+    // explicit end of a Regenerate session.
+    selectionRevision += 1
+    repaintSession = null
+  }
   selection.value = null
   selectionMaster = null
   selectionToDocument = null
@@ -5664,6 +5734,8 @@ function frameAdjust(
 /** Every gesture end republishes: the mask consumers copy, and the master the
  *  geometry sync re-derives from. */
 function onSelectionChange(mask: HTMLCanvasElement | null) {
+  selectionRevision += 1
+  repaintSession = null
   // Any change the Object tool didn't publish itself (a drawn gesture, clear,
   // invert) makes its granularity stack stale — cycling would resurrect the
   // pre-click selection over the user's newer edits.


### PR DESCRIPTION
## Summary

- Align Recently edited sorting with the same lineage-based criteria used by the visible Edited marker.
- Place newly opened editor shelf chips at the front without moving existing chips when activated.
- Route masked blur drags through the authoritative compositor preview.
- Keep iterative Regenerate runs in one selection session, appending candidate rows sampled from the same base.

## Why

The browser sort previously classified edits from direct media metadata while the marker used tool lineage, so the visible marker and ordering could disagree. The shelf ranked new editors correctly but displayed them oldest-first. Masked blur's GPU approximation sampled outside the region differently from the compositor. Regenerate always created a new top edit, causing later prompts to sample the rejected result instead of retaining comparable candidates from the original base.

## Impact

Asset ordering now matches the marker people see. New editor tabs appear where expected without activation jitter. Masked blur previews match committed output. Prompt iteration during an unchanged inpaint selection preserves every candidate set in one edit and automatically shows the first result from the newest set.

## Validation

- `tools/stimma test backend tests/test_assets_api.py -k recently_edited_sort`
- `npm run test:editor-shelf`
- `node --test --experimental-strip-types src/imageEditor/stack/adjustmentParity.test.ts src/imageEditor/stack/repaintSession.test.ts`
- `npm run build`
- `git diff --check`

The broader `npm run test:image-stack` run reports 244 passing and two existing failures in `photoAdjustments.test.ts` (`new tonal and color controls participate in adjustment identity` and `hue adjustment rotates color while retaining saturation`).
