### PR TITLE
Prevent WebKitGTK crashes in the All Assets view

### DIFF
--- a/frontend/src/vendor/vueResize.js
+++ b/frontend/src/vendor/vueResize.js
@@ -1,0 +1,78 @@
+import { defineComponent, h, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+
+export const ResizeObserver = defineComponent({
+  name: 'ResizeObserver',
+  props: {
+    emitOnMount: {
+      type: Boolean,
+      default: false,
+    },
+    ignoreWidth: {
+      type: Boolean,
+      default: false,
+    },
+    ignoreHeight: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ['notify'],
+  setup(props, { emit }) {
+    const element = ref(null)
+    let observer = null
+    let width = 0
+    let height = 0
+
+    function emitSize() {
+      emit('notify', { width, height })
+    }
+
+    function updateSize() {
+      if (!element.value) return
+
+      const nextWidth = element.value.offsetWidth
+      const nextHeight = element.value.offsetHeight
+      const changed = (!props.ignoreWidth && nextWidth !== width)
+        || (!props.ignoreHeight && nextHeight !== height)
+
+      width = nextWidth
+      height = nextHeight
+      if (changed) emitSize()
+    }
+
+    onMounted(async () => {
+      await nextTick()
+      if (!element.value) return
+
+      width = element.value.offsetWidth
+      height = element.value.offsetHeight
+      if (props.emitOnMount) emitSize()
+
+      observer = new window.ResizeObserver(updateSize)
+      observer.observe(element.value)
+    })
+
+    onBeforeUnmount(() => observer?.disconnect())
+
+    return () => h('div', {
+      ref: element,
+      class: 'resize-observer',
+      tabindex: '-1',
+      style: {
+        position: 'absolute',
+        inset: '0',
+        zIndex: '-1',
+        pointerEvents: 'none',
+        overflow: 'hidden',
+        opacity: '0',
+      },
+    })
+  },
+})
+
+export function install(app) {
+  app.component('resize-observer', ResizeObserver)
+  app.component('ResizeObserver', ResizeObserver)
+}
+
+export default { install }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -67,7 +67,14 @@ export default defineConfig(() => ({
     __STIMMA_COMMIT__: JSON.stringify(commitHash),
   },
   resolve: {
-    alias: distributionAliases
+    alias: [
+      // vue-resize uses an <object>-based detector that can crash WebKitGTK.
+      {
+        find: /^vue-resize$/,
+        replacement: resolve(__dirname, 'src/vendor/vueResize.js')
+      },
+      ...distributionAliases
+    ]
   },
   server: {
     port: frontendPort,


### PR DESCRIPTION
The All Assets grid uses `vue-virtual-scroller`, which in turn relies on `vue-resize` to detect changes to its container size. `vue-resize` does this by inserting a hidden `<object>` that loads `about:blank`, then listening for resize events on the embedded document.

This legacy technique has independently been isolated as a WebKitGTK segfault trigger by [Mainsail](https://github.com/mainsail-crew/mainsail/pull/2348) and [OrcaSlicer](https://github.com/OrcaSlicer/OrcaSlicer/pull/13724).

This change replaces the object-based detector with the browser's `ResizeObserver` API while preserving the component API expected by `vue-virtual-scroller`.

Fixes #3