### PR TITLE
Preserve video duration across remix and tool hops

### DIFF
--- a/backend/routes/generation.py
+++ b/backend/routes/generation.py
@@ -2639,6 +2639,8 @@ async def generate_config_from_media(
                     video_config["frame_count"] = params["frame_count"]
                 if params.get("fps") is not None:
                     video_config["fps"] = params["fps"]
+                if params.get("duration") is not None:
+                    video_config["duration"] = params["duration"]
                 # Include loras
                 video_config["loras"] = params.get("loras", [])
                 # Post-processing chain recorded in lineage (the steps that ran)
@@ -3166,6 +3168,7 @@ class ToolHopRequest(BaseModel):
     negative_prompt: str = ""
     input_images: List[dict] = []  # [{path, filename, hash, mediaId, width, height}]
     current_loras: List[dict] = []  # [{lora, weight, enabled}]
+    duration: Optional[float] = None
 
 
 @router.post("/config-for-tool-hop")
@@ -3221,6 +3224,10 @@ async def get_config_for_tool_hop(request: ToolHopRequest):
         "negative_prompt": request.negative_prompt,
         "input_images": request.input_images,
         "matched_loras": matched_loras,
+        **({"duration": request.duration} if (
+            request.duration is not None
+            and "duration" in target_tool_descriptor.parameter_schema.get("properties", {})
+        ) else {}),
     }
 
 

--- a/backend/tests/test_generation.py
+++ b/backend/tests/test_generation.py
@@ -999,6 +999,32 @@ class TestConfigFromMedia:
         assert data.get("loras") == []
         assert data.get("disable_all_loras") is True
 
+    async def test_video_config_preserves_duration(
+        self,
+        generation_client: httpx.AsyncClient,
+        generation_db_session,
+    ):
+        """Modern duration-based video tools retain duration when remixed."""
+        from tests.helpers import create_media_item
+
+        async with generation_db_session() as session:
+            media = await create_media_item(
+                session,
+                file_format="mp4",
+                generation_metadata=json.dumps({
+                    "tool_id": "test:text-to-video:duration-model",
+                    "prompt": "A slow camera move",
+                    "parameters": {"duration": 8, "seed": 123},
+                }),
+            )
+
+        response = await generation_client.post(
+            f"/api/generate/config-from-media/{media.id}",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["duration"] == 8
+
 
 # =============================================================================
 # Job Listing Tests

--- a/frontend/src/utils/parseGenerationConfig.test.ts
+++ b/frontend/src/utils/parseGenerationConfig.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseGenerationConfig } from './parseGenerationConfig.ts'
+
+const baseOptions = {
+  hasPrompt: true,
+  hasFrameCount: false,
+  hasDuration: true,
+  hasResolution: false,
+  hasVideoFrames: false,
+}
+
+test('restores duration for tools that expose a duration parameter', () => {
+  const update = parseGenerationConfig({ duration: 8 }, baseOptions)
+
+  assert.equal(update?.modelParams.duration, 8)
+})
+
+test('does not transfer duration to tools without a duration parameter', () => {
+  const update = parseGenerationConfig(
+    { duration: 8 },
+    { ...baseOptions, hasDuration: false },
+  )
+
+  assert.equal(update?.modelParams.duration, undefined)
+})

--- a/frontend/src/utils/parseGenerationConfig.ts
+++ b/frontend/src/utils/parseGenerationConfig.ts
@@ -60,6 +60,8 @@ export interface ParseOptions {
   hasPrompt: boolean
   /** Whether the tool has frame_count param (video generation) */
   hasFrameCount: boolean
+  /** Whether the tool has a duration param (modern video generation) */
+  hasDuration: boolean
   /** Whether the tool has resolution param (upscale) */
   hasResolution: boolean
   /** Whether the tool uses video frames (start_image in parameter_schema) */
@@ -139,6 +141,9 @@ export function parseGenerationConfig(
   if (data.shift !== undefined) result.modelParams.shift = data.shift
 
   // Video generation specific (tools with frame_count param)
+  if (options.hasDuration && data.duration !== undefined) {
+    result.modelParams.duration = data.duration
+  }
   if (options.hasFrameCount) {
     if (data.frame_count !== undefined) result.modelParams.frameCount = data.frame_count
     if (data.fps !== undefined) result.modelParams.fps = data.fps

--- a/frontend/src/views/ToolView.vue
+++ b/frontend/src/views/ToolView.vue
@@ -4188,6 +4188,7 @@ async function loadPendingGeneration() {
     const update = parseGenerationConfig(data, {
       hasPrompt: hasPrompt.value,
       hasFrameCount: hasFrameCount.value,
+      hasDuration: hasDuration.value,
       hasResolution: hasResolution.value,
       hasVideoFrames: hasVideoFrames.value,
     })
@@ -4330,6 +4331,7 @@ async function loadRemix(mediaId: string) {
     const update = parseGenerationConfig(data, {
       hasPrompt: hasPrompt.value,
       hasFrameCount: hasFrameCount.value,
+      hasDuration: hasDuration.value,
       hasResolution: hasResolution.value,
       hasVideoFrames: hasVideoFrames.value,
     })
@@ -4459,7 +4461,8 @@ async function handleHopToTool(targetTool: { full_tool_id: string; name: string 
       prompt: globalPrefs.value.prompt || '',
       negative_prompt: modelParams.value.negative_prompt || '',
       input_images: allInputImages,
-      current_loras: currentLoras
+      current_loras: currentLoras,
+      duration: hasDuration.value ? modelParams.value.duration : undefined,
     })
 
     const hopConfig = response.data
@@ -4478,6 +4481,7 @@ async function handleHopToTool(targetTool: { full_tool_id: string; name: string 
       prompt: hopConfig.prompt,
       negative_prompt: hopConfig.negative_prompt,
       loras: hopConfig.matched_loras,
+      ...(hopConfig.duration !== undefined ? { duration: hopConfig.duration } : {}),
       // Carry the ORIGINAL (pre-prep) path plus all non-destructive prep settings
       // so the target tool re-applies them rather than baking onto an already-prepped image.
       source_inputs: (hopConfig.input_images || []).map((img: any) => ({


### PR DESCRIPTION
## What changed

- Preserve recorded duration when remixing videos generated by duration-based tools.
- Carry duration through tool hops when the destination supports it.
- Restore duration in the shared frontend generation-config parser.
- Add focused frontend and backend regression coverage.

## Root cause

The video remix endpoint only returned legacy frame_count and fps, while the frontend parser ignored duration. Tool-hop payloads also omitted duration entirely, leaving reused tool instances with their previous stale value.

## Validation

- Frontend parser regression tests
- Focused backend ConfigFromMedia tests
- Frontend production build
- Git diff whitespace check