### PR TITLE
Add profile-bound MCP server and local assistant bridge

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -83,7 +83,7 @@ license:
 ## Python packages
 
 <!-- BEGIN GENERATED: python -->
-127 packages (direct and transitive; the entire environment is bundled with the app).
+136 packages (direct and transitive; the entire environment is bundled with the app).
 
 | Package | Version | License | Source |
 |---|---|---|---|
@@ -91,8 +91,9 @@ license:
 | aiosignal | 1.4.0 | Apache-2.0 | https://github.com/aio-libs/aiosignal |
 | aiosqlite | 0.19.0 | MIT | https://aiosqlite.omnilib.dev |
 | alembic | 1.17.2 | MIT | https://alembic.sqlalchemy.org |
+| annotated-doc | 0.0.5 | MIT | https://github.com/fastapi/annotated-doc |
 | annotated-types | 0.7.0 | MIT | https://github.com/annotated-types/annotated-types |
-| anyio | 3.7.1 | MIT | https://github.com/agronholm/anyio |
+| anyio | 4.14.2 | MIT | https://github.com/agronholm/anyio |
 | attrs | 25.4.0 | MIT | https://www.attrs.org/ |
 | babel | 2.18.0 | BSD | https://babel.pocoo.org/ |
 | bcrypt | 5.0.0 | Apache-2.0 | https://github.com/pyca/bcrypt/ |
@@ -111,7 +112,7 @@ license:
 | cssselect2 | 0.9.0 | BSD | https://doc.courtbouillon.org/cssselect2/ |
 | dateparser | 1.3.0 | BSD | https://github.com/scrapinghub/dateparser |
 | ddgs | 9.11.3 | MIT | https://github.com/deedy5/ddgs |
-| fastapi | 0.104.1 | MIT | https://github.com/tiangolo/fastapi |
+| fastapi | 0.141.1 | MIT | https://github.com/fastapi/fastapi |
 | ffmpeg-python | 0.2.0 | Apache-2.0 | https://github.com/kkroening/ffmpeg-python |
 | filelock | 3.20.1 | Unlicense | https://github.com/tox-dev/py-filelock |
 | flatbuffers | 25.12.19 | Apache-2.0 | https://google.github.io/flatbuffers/ |
@@ -126,14 +127,17 @@ license:
 | hf-xet | 1.2.0 | Apache-2.0 | https://github.com/huggingface/xet-core |
 | htmldate | 1.9.4 | Apache-2.0 | https://htmldate.readthedocs.io |
 | httpcore | 1.0.9 | BSD-3-Clause | https://www.encode.io/httpcore/ |
-| httptools | 0.7.1 | MIT | https://github.com/MagicStack/httptools |
+| httptools | 0.8.0 | MIT | https://github.com/MagicStack/httptools |
 | httpx | 0.28.1 | BSD | https://github.com/encode/httpx |
+| httpx-sse | 0.4.3 | MIT | https://github.com/florimondmanca/httpx-sse |
 | huggingface-hub | 1.4.1 | Apache-2.0 | https://github.com/huggingface/huggingface_hub |
 | humanfriendly | 10.0 | MIT | https://humanfriendly.readthedocs.io |
 | idna | 3.11 | BSD-3-Clause | https://github.com/kjd/idna |
 | imageio | 2.37.2 | BSD-2-Clause | https://github.com/imageio/imageio |
 | imgviz | 1.8.0 | MIT | https://github.com/wkentaro/imgviz |
 | jeepney | 0.9.0 | MIT | https://gitlab.com/takluyver/jeepney |
+| jsonschema | 4.26.0 | MIT | https://github.com/python-jsonschema/jsonschema |
+| jsonschema-specifications | 2025.9.1 | MIT | https://github.com/python-jsonschema/jsonschema-specifications |
 | justext | 3.0.2 | BSD | https://github.com/miso-belica/jusText |
 | lazy-loader | 0.4 | BSD | https://github.com/scientific-python/lazy_loader |
 | loguru | 0.7.3 | MIT | https://github.com/Delgan/loguru |
@@ -143,6 +147,7 @@ license:
 | markdown | 3.10.1 | BSD-3-Clause | https://Python-Markdown.github.io/ |
 | markdown-it-py | 4.0.0 | MIT | https://github.com/executablebooks/markdown-it-py |
 | markupsafe | 3.0.3 | BSD-3-Clause | https://github.com/pallets/markupsafe/ |
+| mcp | 1.29.1 | MIT | https://modelcontextprotocol.io |
 | mdurl | 0.1.2 | MIT | https://github.com/executablebooks/mdurl |
 | mpmath | 1.3.0 | BSD | http://mpmath.org/ |
 | multidict | 6.7.0 | Apache License 2.0 | https://github.com/aio-libs/multidict |
@@ -161,11 +166,12 @@ license:
 | protobuf | 6.33.2 | 3-Clause BSD License | https://developers.google.com/protocol-buffers/ |
 | psutil | 7.2.2 | BSD-3-Clause | https://github.com/giampaolo/psutil |
 | pycparser | 3.0 | BSD-3-Clause | https://github.com/eliben/pycparser |
-| pydantic | 2.5.0 | MIT | https://github.com/pydantic/pydantic |
-| pydantic-core | 2.14.1 | MIT | https://github.com/pydantic/pydantic-core |
-| pydantic-settings | 2.1.0 | MIT | https://github.com/pydantic/pydantic-settings |
+| pydantic | 2.13.5 | MIT | https://github.com/pydantic/pydantic |
+| pydantic-core | 2.46.5 | MIT | https://github.com/pydantic/pydantic |
+| pydantic-settings | 2.15.0 | MIT | https://github.com/pydantic/pydantic-settings |
 | pydyf | 0.12.1 | BSD | https://www.courtbouillon.org/pydyf |
 | pygments | 2.19.2 | BSD | https://pygments.org |
+| pyjwt | 2.13.0 | MIT | https://github.com/jpadilla/pyjwt |
 | pypdfium2 | 5.6.0 | BSD-3-Clause AND Apache-2.0 (bundles PDFium and its third-party libraries) | https://github.com/pypdfium2-team/pypdfium2 |
 | pyphen | 0.17.2 | GPL-2.0+ OR LGPL-2.1+ OR MPL-1.1 (used under MPL-1.1) | https://www.courtbouillon.org/pyphen |
 | pyreadline3 | 3.5.4 | BSD-3-Clause | https://github.com/pyreadline3/pyreadline3 |
@@ -173,23 +179,25 @@ license:
 | python-dateutil | 2.9.0.post0 | BSD | https://github.com/dateutil/dateutil |
 | python-dotenv | 1.2.1 | BSD-3-Clause | https://github.com/theskumar/python-dotenv |
 | python-frontmatter | 1.1.0 | MIT | https://github.com/eyeseast/python-frontmatter |
-| python-multipart | 0.0.6 | Apache-2.0 | https://github.com/andrew-d/python-multipart |
+| python-multipart | 0.0.32 | Apache-2.0 | https://github.com/Kludex/python-multipart |
 | pytz | 2026.1.post1 | MIT | http://pythonhosted.org/pytz |
+| pywin32 | 312 | PSF-2.0 AND BSD-3-Clause AND (PSF-2.0 OR BSD-3-Clause) AND Python-2.0.1 AND MIT AND LGPL-2.1-or-later | https://github.com/mhammond/pywin32 |
 | pyyaml | 6.0.1 | MIT | https://pyyaml.org/ |
+| referencing | 0.37.0 | MIT | https://github.com/python-jsonschema/referencing |
 | regex | 2025.11.3 | Apache-2.0 AND CNRI-Python | https://github.com/mrabarnett/mrab-regex |
 | requests | 2.32.5 | Apache-2.0 | https://requests.readthedocs.io |
 | rich | 14.3.2 | MIT | https://github.com/Textualize/rich |
+| rpds-py | 2026.6.3 | MIT | https://github.com/crate-py/rpds |
 | ruamel-yaml | 0.19.1 | MIT | https://sourceforge.net/p/ruamel-yaml/code/ci/default/tree/ |
 | scikit-image | 0.23.2 | BSD | https://scikit-image.org |
 | scipy | 1.16.3 | BSD | https://scipy.org/ |
 | secretstorage | 3.5.0 | BSD-3-Clause | https://github.com/mitya57/secretstorage |
 | shellingham | 1.5.4 | ISC | https://github.com/sarugaku/shellingham |
 | six | 1.17.0 | MIT | https://github.com/benjaminp/six |
-| sniffio | 1.3.1 | MIT | https://github.com/python-trio/sniffio |
 | soupsieve | 2.8.1 | MIT | https://github.com/facelessuser/soupsieve |
 | sqlalchemy | 2.0.23 | MIT | https://www.sqlalchemy.org |
 | sse-starlette | 1.8.2 | BSD | https://github.com/sysid/sse-starlette |
-| starlette | 0.27.0 | BSD-3-Clause | https://github.com/encode/starlette |
+| starlette | 1.6.0 | BSD-3-Clause | https://github.com/Kludex/starlette |
 | strip-markdown | 1.3 | MIT | https://github.com/D3r3k23/strip_markdown |
 | structlog | 25.5.0 | MIT OR Apache-2.0 | https://www.structlog.org/ |
 | sympy | 1.14.0 | BSD | https://sympy.org |
@@ -201,10 +209,11 @@ license:
 | trafilatura | 2.0.0 | Apache-2.0 | https://trafilatura.readthedocs.io |
 | typer-slim | 0.21.1 | MIT | https://github.com/fastapi/typer |
 | typing-extensions | 4.15.0 | PSF-2.0 | https://github.com/python/typing_extensions |
+| typing-inspection | 0.4.4 | MIT | https://github.com/pydantic/typing-inspection |
 | tzdata | 2025.3 | Apache-2.0 | https://github.com/python/tzdata |
 | tzlocal | 5.3.1 | MIT | https://github.com/regebro/tzlocal |
 | urllib3 | 2.6.2 | MIT | https://github.com/urllib3/urllib3/blob/main/CHANGES.rst |
-| uvicorn | 0.24.0 | BSD-3-Clause | https://www.uvicorn.org/ |
+| uvicorn | 0.50.1 | BSD-3-Clause | https://uvicorn.dev/ |
 | uvloop | 0.22.1 | Apache-2.0 | https://github.com/MagicStack/uvloop |
 | watchfiles | 1.1.1 | MIT | https://github.com/samuelcolvin/watchfiles |
 | wcwidth | 0.2.14 | MIT | https://github.com/jquast/wcwidth |

--- a/backend/agent/tests/test_stp_permission_gate.py
+++ b/backend/agent/tests/test_stp_permission_gate.py
@@ -131,14 +131,14 @@ async def test_gate_ask_blocks_then_approves(monkeypatch):
     # Let the gate register + raise the card, then confirm it is parked.
     await asyncio.sleep(0.01)
     assert not task.done()
-    assert cards == ["7:p:t"]
-    assert is_pending_permission("7:p:t")
+    assert cards == [gate._request_id(7, "p:t")]
+    assert is_pending_permission(gate._request_id(7, "p:t"))
 
     # Resolve as approved → the parked task completes and caches allow.
-    assert resolve_pending_permission("7:p:t", {"approved": True, "scope": "once"})
+    assert resolve_pending_permission(gate._request_id(7, "p:t"), {"approved": True, "scope": "once"})
     await asyncio.wait_for(task, timeout=1)
     assert cache["p:t"] is True
-    assert not is_pending_permission("7:p:t")  # registry cleaned up
+    assert not is_pending_permission(gate._request_id(7, "p:t"))  # registry cleaned up
 
 
 @pytest.mark.asyncio
@@ -156,7 +156,7 @@ async def test_gate_ask_blocks_then_denies(monkeypatch):
         ensure_tool_permission(chat_id=8, tool_id="p:t", kwargs={}, run_cache={})
     )
     await asyncio.sleep(0.01)
-    resolve_pending_permission("8:p:t", {"approved": False, "scope": "once"})
+    resolve_pending_permission(gate._request_id(8, "p:t"), {"approved": False, "scope": "once"})
     with pytest.raises(ToolPermissionDenied):
         await asyncio.wait_for(task, timeout=1)
 
@@ -184,7 +184,7 @@ async def test_gate_ask_dedups_concurrent_calls(monkeypatch):
     ]
     await asyncio.sleep(0.01)
     assert len(cards) == 1  # deduped to a single card
-    resolve_pending_permission("9:p:t", {"approved": True, "scope": "chat"})
+    resolve_pending_permission(gate._request_id(9, "p:t"), {"approved": True, "scope": "chat"})
     await asyncio.wait_for(asyncio.gather(*tasks), timeout=1)
     assert cache["p:t"] is True
 
@@ -204,8 +204,8 @@ async def test_gate_ask_interrupt_cleans_registry(monkeypatch):
         ensure_tool_permission(chat_id=10, tool_id="p:t", kwargs={}, run_cache={})
     )
     await asyncio.sleep(0.01)
-    assert is_pending_permission("10:p:t")
+    assert is_pending_permission(gate._request_id(10, "p:t"))
     task.cancel()  # simulates interrupt/stop cancelling the run_code task
     with pytest.raises(asyncio.CancelledError):
         await task
-    assert not is_pending_permission("10:p:t")  # finally-block cleaned up
+    assert not is_pending_permission(gate._request_id(10, "p:t"))  # finally-block cleaned up

--- a/backend/agent/v2/code_runtime.py
+++ b/backend/agent/v2/code_runtime.py
@@ -1190,6 +1190,9 @@ class StimmaSDK:
                 kwargs["_input_preprocessors"] = preprocessors
                 kwargs["_input_preprocessor_params"] = preprocessor_params
 
+        from mcp_server.jobs import check_execution
+        check_execution()
+
         # Single STP parameter namespace — hand the flat kwargs straight through.
         parameters = dict(kwargs)
         prompt_val = parameters.get("prompt")

--- a/backend/agent/v2/service.py
+++ b/backend/agent/v2/service.py
@@ -35,39 +35,46 @@ from .workspace import get_project_workspace, get_workspace_dir
 log = get_logger(__name__)
 
 # Track active executions to prevent concurrent runs on the same chat
-_active_chat_executions: set[int] = set()
-_active_chat_tasks: dict[int, asyncio.Task] = {}
-_interrupt_flags: dict[int, bool] = {}
+_active_chat_executions: set[tuple[str, int]] = set()
+_active_chat_tasks: dict[tuple[str, int], asyncio.Task] = {}
+_interrupt_flags: dict[tuple[str, int], bool] = {}
+
+
+def _chat_key(chat_id: int) -> tuple[str, int]:
+    from core.profile_context import get_current_profile
+    return get_current_profile(), chat_id
 
 def is_execution_active(chat_id: int) -> bool:
     """Check if there's an active agent execution for this chat."""
-    return chat_id in _active_chat_executions
+    return _chat_key(chat_id) in _active_chat_executions
 
 
 def get_active_chat_ids() -> list[int]:
     """Return chat ids with an active agent execution."""
-    return sorted(_active_chat_executions)
+    from core.profile_context import get_current_profile
+    profile_id = get_current_profile()
+    return sorted(chat_id for profile, chat_id in _active_chat_executions if profile == profile_id)
 
 
 def get_active_task(chat_id: int) -> Optional[asyncio.Task]:
     """Return the asyncio task of the active execution for this chat, if any."""
-    return _active_chat_tasks.get(chat_id)
+    return _active_chat_tasks.get(_chat_key(chat_id))
 
 
 def _mark_running(chat_id: int) -> None:
-    _interrupt_flags[chat_id] = False
+    _interrupt_flags[_chat_key(chat_id)] = False
 
 
 def _mark_interrupted(chat_id: int) -> None:
-    _interrupt_flags[chat_id] = True
+    _interrupt_flags[_chat_key(chat_id)] = True
 
 
 def _clear_interrupt(chat_id: int) -> None:
-    _interrupt_flags.pop(chat_id, None)
+    _interrupt_flags.pop(_chat_key(chat_id), None)
 
 
 def _is_interrupted(chat_id: int) -> bool:
-    return bool(_interrupt_flags.get(chat_id))
+    return bool(_interrupt_flags.get(_chat_key(chat_id)))
 
 
 def _max_turns_for_chat(chat: Chat) -> int:
@@ -137,6 +144,8 @@ class _AgentInterrupted(Exception):
 
 
 def _raise_if_interrupted(chat_id: int) -> None:
+    from mcp_server.jobs import check_execution
+    check_execution()
     if _is_interrupted(chat_id):
         raise _AgentInterrupted()
 
@@ -902,15 +911,15 @@ async def run_agent(
     # it does, the frontend has already marked the agent as running, so a
     # silent return would leave it waiting for an agent_stopped that never
     # comes. Broadcast one so the UI recovers.
-    if chat_id in _active_chat_executions:
+    if _chat_key(chat_id) in _active_chat_executions:
         log.warning(f"Chat {chat_id}: Agent already running, skipping")
         await ws_manager.broadcast("agent_stopped", {"chat_id": chat_id, "reason": "already_running"})
         return
-    _active_chat_executions.add(chat_id)
+    _active_chat_executions.add(_chat_key(chat_id))
     _mark_running(chat_id)
     current_task = asyncio.current_task()
     if current_task:
-        _active_chat_tasks[chat_id] = current_task
+        _active_chat_tasks[_chat_key(chat_id)] = current_task
 
     # Copy any user-selected media into the workspace so the agent can access them
     if selected_media_ids:
@@ -1075,8 +1084,8 @@ async def run_agent(
         _track_agent_turn("failed", error_type=_error_type)
 
     finally:
-        _active_chat_executions.discard(chat_id)
-        _active_chat_tasks.pop(chat_id, None)
+        _active_chat_executions.discard(_chat_key(chat_id))
+        _active_chat_tasks.pop(_chat_key(chat_id), None)
         _clear_interrupt(chat_id)
 
 
@@ -1916,11 +1925,11 @@ async def resume_after_hitl(
         return
 
     # Approved — resume the agentic loop
-    _active_chat_executions.add(chat_id)
+    _active_chat_executions.add(_chat_key(chat_id))
     _mark_running(chat_id)
     current_task = asyncio.current_task()
     if current_task:
-        _active_chat_tasks[chat_id] = current_task
+        _active_chat_tasks[_chat_key(chat_id)] = current_task
     await ws_manager.broadcast("agent_started", {"chat_id": chat_id})
 
     try:
@@ -2036,8 +2045,8 @@ async def resume_after_hitl(
         await ws_manager.broadcast("agent_stopped", {"chat_id": chat_id, "reason": "error", "error": str(e)})
 
     finally:
-        _active_chat_executions.discard(chat_id)
-        _active_chat_tasks.pop(chat_id, None)
+        _active_chat_executions.discard(_chat_key(chat_id))
+        _active_chat_tasks.pop(_chat_key(chat_id), None)
         _clear_interrupt(chat_id)
 
 
@@ -2100,11 +2109,11 @@ async def resume_after_ask_user(
     })
 
     # Re-enter the agentic loop
-    _active_chat_executions.add(chat_id)
+    _active_chat_executions.add(_chat_key(chat_id))
     _mark_running(chat_id)
     current_task = asyncio.current_task()
     if current_task:
-        _active_chat_tasks[chat_id] = current_task
+        _active_chat_tasks[_chat_key(chat_id)] = current_task
     await ws_manager.broadcast("agent_started", {"chat_id": chat_id})
 
     try:
@@ -2139,8 +2148,8 @@ async def resume_after_ask_user(
         await ws_manager.broadcast("agent_stopped", {"chat_id": chat_id, "reason": "error", "error": str(e)})
 
     finally:
-        _active_chat_executions.discard(chat_id)
-        _active_chat_tasks.pop(chat_id, None)
+        _active_chat_executions.discard(_chat_key(chat_id))
+        _active_chat_tasks.pop(_chat_key(chat_id), None)
         _clear_interrupt(chat_id)
 
 
@@ -2152,11 +2161,11 @@ async def interrupt_execution(
     """Interrupt an active v2 execution immediately."""
     chat_id = chat.id
 
-    was_active = chat_id in _active_chat_executions
+    was_active = _chat_key(chat_id) in _active_chat_executions
     _mark_interrupted(chat_id)
-    _active_chat_executions.discard(chat_id)
+    _active_chat_executions.discard(_chat_key(chat_id))
 
-    task = _active_chat_tasks.get(chat_id)
+    task = _active_chat_tasks.get(_chat_key(chat_id))
     if task and not task.done():
         task.cancel()
 

--- a/backend/agent/v2/tool_permission_gate.py
+++ b/backend/agent/v2/tool_permission_gate.py
@@ -51,7 +51,8 @@ _PENDING: dict[str, asyncio.Future] = {}
 
 
 def _request_id(chat_id: int, tool_id: str) -> str:
-    return f"{chat_id}:{tool_id}"
+    from core.profile_context import get_current_profile
+    return f"{get_current_profile()}:{chat_id}:{tool_id}"
 
 
 def is_pending_permission(request_id: str) -> bool:

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -13,6 +13,7 @@ config = context.config
 # add your model's MetaData object here
 # for 'autogenerate' support
 from database import Base
+from mcp_server import models as mcp_models  # register profile MCP tables
 target_metadata = Base.metadata
 
 # other values from the config, defined by the needs of env.py,

--- a/backend/alembic/versions/mcp01_profile_mcp.py
+++ b/backend/alembic/versions/mcp01_profile_mcp.py
@@ -1,0 +1,48 @@
+"""Profile MCP client identities and durable operation receipts.
+
+Revision ID: mcp01
+Revises: t1u2v3w4x5y6
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "mcp01"
+down_revision = "t1u2v3w4x5y6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "mcp_clients",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("profile_id", sa.String(), nullable=False),
+        sa.Column("credential_hash", sa.String(), nullable=False, unique=True),
+        sa.Column("installation", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("deleted_at", sa.DateTime()),
+    )
+    op.create_table(
+        "mcp_operations",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("client_id", sa.String(), nullable=False),
+        sa.Column("operation", sa.String(), nullable=False),
+        sa.Column("request_key", sa.String(), nullable=False),
+        sa.Column("input_hash", sa.String(), nullable=False),
+        sa.Column("state", sa.String(), nullable=False),
+        sa.Column("input_json", sa.Text(), nullable=False),
+        sa.Column("result_json", sa.Text()),
+        sa.Column("chat_id", sa.Integer()),
+        sa.Column("controller_version", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("deleted_at", sa.DateTime()),
+        sa.UniqueConstraint("operation", "request_key", name="uq_mcp_request"),
+    )
+
+
+def downgrade():
+    op.drop_table("mcp_operations")
+    op.drop_table("mcp_clients")

--- a/backend/config.py
+++ b/backend/config.py
@@ -557,6 +557,7 @@ class ProfileConfig(BaseModel):
     lora_denylist: List[str] = []   # Glob patterns - these are denied (allowlist can override)
     wildcards: List[WildcardEntry] = []  # Named wildcard lists for prompt expansion
     prompt_segments: List[PromptSegmentEntry] = []  # Named text blocks for prompt expansion
+    mcp_enabled: bool = False
     pin_hash: Optional[str] = None  # bcrypt hash of profile PIN (None = no PIN required)
     pin_idle_timeout_minutes: int = 30  # Minutes of inactivity before PIN is required again
     agent: ProfileAgentConfig = ProfileAgentConfig()  # Per-profile agent settings
@@ -1354,6 +1355,7 @@ class Settings(BaseSettings):
                     prompt_segments=profile_prompt_segments,
                     lora_allowlist=profile.get('lora_allowlist', []),
                     lora_denylist=profile.get('lora_denylist', []),
+                    mcp_enabled=profile.get('mcp_enabled', False),
                     pin_hash=profile.get('pin_hash'),
                     pin_idle_timeout_minutes=profile.get('pin_idle_timeout_minutes', 30),
                     agent=profile_agent,

--- a/backend/core/app.py
+++ b/backend/core/app.py
@@ -1379,7 +1379,9 @@ async def lifespan(app: FastAPI):
 
     # Yield - server starts accepting requests
     # Background tasks are already running concurrently
-    yield
+    from mcp_server.server import lifespan as mcp_lifespan
+    async with mcp_lifespan():
+        yield
 
     # === SHUTDOWN ===
     log.info("shutdown begin")

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -117,6 +117,10 @@ class ProfileMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         path = request.url.path
+        if path.startswith('/mcp/'):
+            # The MCP ASGI gateway authenticates and binds its own immutable
+            # profile. Do not inject the REST fallback profile or PIN semantics.
+            return await call_next(request)
 
         # Check if this route is exempt from profile requirements
         is_exempt = (

--- a/backend/core/slowtrace.py
+++ b/backend/core/slowtrace.py
@@ -35,7 +35,8 @@ def _skip_detailed_logging(path: str) -> bool:
     /api/db/{guid}/thumbnail/{hash}).
     """
     return (
-        path in SKIP_PATHS
+        path.startswith("/mcp/")
+        or path in SKIP_PATHS
         or any(path.startswith(prefix) for prefix in SKIP_PREFIXES)
         or "/thumbnail/" in path
         or path.endswith("/thumbnail")

--- a/backend/flow_runtime/engine.py
+++ b/backend/flow_runtime/engine.py
@@ -1486,6 +1486,9 @@ class FlowRun:
             if self.config.hitl_auto_resolve is not None:
                 try:
                     resolution = self.config.hitl_auto_resolve(eq, resolved_inputs)
+                    import inspect
+                    if inspect.isawaitable(resolution):
+                        resolution = await resolution
                     completion_value = self._hitl_completion_value(eq, resolution)
                 except Exception as exc:
                     self._finalize_failure(eq, str(exc), category=CODE_ERROR)

--- a/backend/flow_runtime/production_evaluators.py
+++ b/backend/flow_runtime/production_evaluators.py
@@ -625,6 +625,15 @@ async def _run_single_tool_job(
     if seed is not None and "seed" not in parameters:
         parameters["seed"] = seed
     async with _open_session() as session:
+        from mcp_server.jobs import check_execution, execution_chat
+        check_execution()
+        if execution_chat.get() is not None:
+            from sqlalchemy.ext.asyncio import async_sessionmaker
+            from agent.v2.tool_permission_gate import ensure_tool_permission
+            await ensure_tool_permission(chat_id=execution_chat.get(), tool_id=tool_id,
+                kwargs=parameters, task_type=None, run_cache={},
+                session_maker=async_sessionmaker(session.bind, expire_on_commit=False))
+            check_execution()
         return await execute_call_tool(
             tool_id=tool_id,
             parameters=parameters,

--- a/backend/main.py
+++ b/backend/main.py
@@ -178,6 +178,10 @@ async def root():
     return {"status": "ok", "service": "Stimma API"}
 
 # Include all routers
+from mcp_server.settings import router as mcp_settings_router
+from mcp_server.server import Gateway
+app.include_router(mcp_settings_router)
+app.mount('/mcp', Gateway())
 app.include_router(auth.router)
 app.include_router(provider_manage.router)
 app.include_router(assets.router)

--- a/backend/mcp_server/__init__.py
+++ b/backend/mcp_server/__init__.py
@@ -1,0 +1,1 @@
+"""Profile-bound inbound MCP adapters over Stimma's workspace services."""

--- a/backend/mcp_server/access.py
+++ b/backend/mcp_server/access.py
@@ -1,0 +1,201 @@
+"""MCP credentials are independent of REST sessions and UI PIN unlocks."""
+
+from __future__ import annotations
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from sqlalchemy import select
+from config import get_settings
+from database_registry import get_database_registry
+from .models import McpClient
+
+
+class McpError(Exception):
+    def __init__(self, code: str, message: str):
+        self.code, self.message = code, message
+        super().__init__(message)
+
+
+def installation_secret() -> bytes:
+    # Outside profile snapshots. Copying a profile DB never copies client authority.
+    from app_dirs import get_data_dir
+
+    path = Path(get_data_dir()) / "mcp-installation.key"
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        pass
+    else:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(secrets.token_bytes(32))
+    return path.read_bytes()
+
+
+def installation_id() -> str:
+    return hashlib.sha256(installation_secret()).hexdigest()
+
+
+@dataclass(frozen=True)
+class Caller:
+    profile_id: str
+    client_id: str
+    database_id: str
+    stamp: str
+
+    @property
+    def key(self):
+        return self.profile_id, self.client_id
+
+
+@dataclass
+class Unlock:
+    stamp: str
+    last_activity: float
+    grant: str
+
+
+class Access:
+    def __init__(self):
+        self.unlocks: dict[tuple[str, str], Unlock] = {}
+        self.failures: dict[str, tuple[int, float]] = {}
+        self.pin_locks: dict[str, asyncio.Lock] = {}
+
+    def stamp(self, profile_id):
+        profile = get_settings().get_profile(profile_id)
+        if not profile or not profile.mcp_enabled:
+            raise McpError("profile_disabled", "MCP is disabled for this profile.")
+        db = get_database_registry().get_database(profile_id)
+        # DB object identity also invalidates live grants on database replacement.
+        stamp = hashlib.sha256(
+            f"{db.db_guid}:{id(db)}:{profile.pin_hash}:{profile.mcp_enabled}".encode()
+        ).hexdigest()
+        return profile, db, stamp
+
+    async def authenticate(self, profile_id: str, credential: str) -> Caller:
+        profile, db, stamp = self.stamp(profile_id)
+        digest = hashlib.sha256(credential.encode()).hexdigest()
+        async with db.async_session_maker() as session:
+            client = (
+                await session.execute(
+                    select(McpClient).where(
+                        McpClient.credential_hash == digest,
+                        McpClient.profile_id == profile_id,
+                        McpClient.installation == installation_id(),
+                        McpClient.deleted_at.is_(None),
+                    )
+                )
+            ).scalar_one_or_none()
+            if not client:
+                raise McpError(
+                    "unauthorized", "This assistant connection is not authorized."
+                )
+            return Caller(profile_id, client.id, db.db_guid, stamp)
+
+    def status(self, caller):
+        profile, _, stamp = self.stamp(caller.profile_id)
+        unlock = self.unlocks.get(caller.key)
+        timeout = max(1, profile.pin_idle_timeout_minutes) * 60
+        unlocked = bool(
+            unlock
+            and unlock.stamp == stamp == caller.stamp
+            and time.time() - unlock.last_activity < timeout
+        )
+        return {
+            "locked": not unlocked,
+            "requires_pin": bool(profile.pin_hash),
+            "expires_at": unlock.last_activity + timeout if unlocked else None,
+        }
+
+    def require(self, caller, *, activity=True):
+        if self.status(caller)["locked"]:
+            raise McpError(
+                "profile_locked",
+                "Unlock this profile with access_open using the PIN supplied by the user.",
+            )
+        if activity:
+            self.unlocks[caller.key].last_activity = time.time()
+        return self.unlocks[caller.key]
+
+    async def open(self, caller, pin=None):
+        async with self.pin_locks.setdefault(caller.profile_id, asyncio.Lock()):
+            profile, _, stamp = self.stamp(caller.profile_id)
+            failures, retry_at = self.failures.get(caller.profile_id, (0, 0))
+            if time.time() < retry_at:
+                raise McpError(
+                    "unlock_rate_limited",
+                    "Wait before trying another user-supplied PIN.",
+                )
+            if profile.pin_hash:
+                import bcrypt
+
+                raw = (pin or "").encode()
+                valid = len(raw) <= 72 and await asyncio.to_thread(
+                    bcrypt.checkpw, raw, profile.pin_hash.encode()
+                )
+                if not valid:
+                    failures += 1
+                    self.failures[caller.profile_id] = (
+                        failures,
+                        time.time() + min(300, 2 ** min(failures, 9)),
+                    )
+                    raise McpError(
+                        "invalid_pin",
+                        "The PIN was not accepted. Ask the user; do not guess or retry it.",
+                    )
+            self.failures.pop(caller.profile_id, None)
+            self.unlocks[caller.key] = Unlock(
+                stamp, time.time(), secrets.token_urlsafe(18)
+            )
+            return self.status(caller)
+
+    def lock(self, profile_id, client_id=None):
+        if client_id is None:
+            from .ui_context import clear
+
+            clear(profile_id)
+        for key in list(self.unlocks):
+            if key[0] == profile_id and (client_id is None or key[1] == client_id):
+                self.unlocks.pop(key, None)
+
+    def ref(self, caller, kind, identifier):
+        payload = json.dumps(
+            [caller.profile_id, caller.database_id, kind, str(identifier)],
+            separators=(",", ":"),
+        ).encode()
+        encoded = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+        signature = hmac.new(
+            installation_secret(), payload, hashlib.sha256
+        ).hexdigest()[:32]
+        return f"{kind}:{encoded}.{signature}"
+
+    def resolve(self, caller, reference, kind):
+        try:
+            prefix, encoded = reference.split(":", 1)
+            encoded, signature = encoded.rsplit(".", 1)
+            payload = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+            expected = hmac.new(
+                installation_secret(), payload, hashlib.sha256
+            ).hexdigest()[:32]
+            profile, database, actual_kind, identifier = json.loads(payload)
+            if not hmac.compare_digest(signature, expected) or (
+                profile,
+                database,
+                actual_kind,
+                prefix,
+            ) != (caller.profile_id, caller.database_id, kind, kind):
+                raise ValueError()
+            return identifier
+        except (ValueError, TypeError, AttributeError):
+            raise McpError(
+                "not_found", "Reference is unavailable in this profile."
+            ) from None
+
+
+access = Access()

--- a/backend/mcp_server/bridge.py
+++ b/backend/mcp_server/bridge.py
@@ -1,0 +1,251 @@
+"""Packaged stdio bridge. No PIN persistence; only this client's transport credential."""
+
+from __future__ import annotations
+import argparse
+import asyncio
+from contextlib import asynccontextmanager
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from urllib.parse import quote, urlparse
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import Tool, TextContent, CallToolResult, ToolAnnotations
+
+
+def config_dir():
+    return (
+        Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+        / "stimma"
+        / "mcp"
+    )
+
+
+def config_path(alias):
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,100}", alias):
+        raise ValueError("Invalid connection alias")
+    return config_dir() / (alias + ".json")
+
+
+def validate(config):
+    url = urlparse(config["endpoint"])
+    if (
+        url.scheme not in ("http", "https")
+        or url.username
+        or url.password
+        or url.query
+        or url.fragment
+    ):
+        raise ValueError(
+            "Expected an HTTP endpoint without embedded credentials or query parameters"
+        )
+    if not url.path.startswith("/mcp/profiles/"):
+        raise ValueError("Expected a profile-bound MCP endpoint")
+    if not isinstance(config.get("credential"), str) or len(config["credential"]) < 32:
+        raise ValueError("Missing connection credential")
+    return config
+
+
+def install(path):
+    config = validate(json.loads(Path(path).read_text()))
+    target = config_path(config["alias"])
+    target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as stream:
+        json.dump(config, stream)
+    os.chmod(target, 0o600)
+    print(
+        json.dumps(
+            {
+                "mcpServers": {
+                    config["alias"]: {
+                        "command": "stimma",
+                        "args": ["mcp", "bridge", config["alias"]],
+                    }
+                }
+            },
+            indent=2,
+        )
+    )
+
+
+async def serve(config):
+    from .logging import protect_sdk_logs
+
+    protect_sdk_logs()
+    bridge = Server(
+        "Stimma bridge",
+        instructions="Stimma creative workspace. Use direct operations for known tasks and agent_start for creative judgment. PIN unlock is shared by this configured client. Never guess a PIN or restart an accepted job to check progress.",
+    )
+    endpoint = config["endpoint"].rstrip("/")
+    headers = {"Authorization": "Bearer " + config["credential"]}
+
+    @asynccontextmanager
+    async def remote():
+        async with httpx.AsyncClient(
+            headers=headers, timeout=60, follow_redirects=False
+        ) as http:
+            async with streamable_http_client(endpoint, http_client=http) as (
+                read,
+                write,
+                _,
+            ):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    yield session
+
+    @bridge.list_tools()
+    async def list_tools():
+        async with remote() as session:
+            result = await session.list_tools()
+        result.tools.extend(
+            [
+                Tool(
+                    name="media_upload",
+                    description="Upload a file selected on this assistant’s machine into the bound Stimma profile. Requires an unlocked connection.",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                        "required": ["path"],
+                        "additionalProperties": False,
+                    },
+                    annotations=ToolAnnotations(
+                        readOnlyHint=False, idempotentHint=True
+                    ),
+                ),
+                Tool(
+                    name="media_download",
+                    description="Download an original or complete bundle to this assistant’s machine and return its local path. Does not publish the media.",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {"ref": {"type": "string"}},
+                        "required": ["ref"],
+                        "additionalProperties": False,
+                    },
+                    annotations=ToolAnnotations(readOnlyHint=True),
+                ),
+            ]
+        )
+        return result.tools
+
+    @bridge.call_tool()
+    async def call_tool(name, arguments):
+        try:
+            if name == "media_upload":
+                path = Path(arguments["path"]).expanduser()
+                if not path.is_file() or path.stat().st_size > 512 * 1024 * 1024:
+                    raise ValueError("Choose an existing file smaller than 512 MiB.")
+
+                async def chunks():
+                    with path.open("rb") as stream:
+                        while data := stream.read(1024 * 1024):
+                            yield data
+
+                async with httpx.AsyncClient(
+                    headers=headers, timeout=120, follow_redirects=False
+                ) as http:
+                    response = await http.post(
+                        endpoint + "/upload",
+                        content=chunks(),
+                        headers={
+                            "X-Filename": quote(path.name),
+                            "Content-Type": "application/octet-stream",
+                        },
+                    )
+                    response.raise_for_status()
+                    value = response.json()
+                return CallToolResult(
+                    content=[TextContent(type="text", text=json.dumps(value))],
+                    structuredContent=value,
+                )
+            if name == "media_download":
+                async with remote() as session:
+                    result = await session.call_tool(
+                        "media_export", {"ref": arguments["ref"]}
+                    )
+                if result.isError:
+                    return result
+                value = result.structuredContent or json.loads(result.content[0].text)
+                folder = Path(
+                    config.get(
+                        "download_directory", Path.home() / "Downloads" / "Stimma"
+                    )
+                )
+                folder.mkdir(parents=True, exist_ok=True)
+                import uuid
+
+                target = folder / (
+                    uuid.uuid4().hex[:8] + "-" + Path(value["filename"]).name
+                )
+                partial = target.with_name(target.name + ".part")
+                digest = hashlib.sha256()
+                try:
+                    async with httpx.AsyncClient(
+                        headers=headers, timeout=120, follow_redirects=False
+                    ) as http:
+                        async with http.stream(
+                            "GET",
+                            endpoint
+                            + "/download/"
+                            + quote(value["transfer_handle"], safe=""),
+                        ) as response:
+                            response.raise_for_status()
+                            with partial.open("xb") as stream:
+                                async for data in response.aiter_bytes():
+                                    digest.update(data)
+                                    stream.write(data)
+                            expected = response.headers.get("x-content-sha256")
+                    if expected and expected != digest.hexdigest():
+                        raise ValueError(
+                            "Checksum mismatch; request the download again."
+                        )
+                    partial.replace(target)
+                finally:
+                    partial.unlink(missing_ok=True)
+                value = {
+                    "path": str(target),
+                    "sha256": digest.hexdigest(),
+                    "media_ref": value["media_ref"],
+                }
+                return CallToolResult(
+                    content=[TextContent(type="text", text=json.dumps(value))],
+                    structuredContent=value,
+                )
+            async with remote() as session:
+                return await session.call_tool(name, arguments)
+        except Exception:
+            # HTTP errors can include request URLs; never expose credentials or PINs.
+            return CallToolResult(
+                isError=True,
+                content=[
+                    TextContent(
+                        type="text",
+                        text="Stimma could not complete the request. Check the backend connection and unlock status. Retry accepted work with the same request_key.",
+                    )
+                ],
+            )
+
+    async with stdio_server() as (read, write):
+        await bridge.run(read, write, bridge.create_initialization_options())
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Stimma MCP bridge")
+    parser.add_argument("action", choices=["install", "bridge"])
+    parser.add_argument("target")
+    args = parser.parse_args()
+    if args.action == "install":
+        install(args.target)
+    else:
+        config = validate(json.loads(config_path(args.target).read_text()))
+        asyncio.run(serve(config))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/mcp_server/content.py
+++ b/backend/mcp_server/content.py
@@ -1,0 +1,146 @@
+"""Saved-image transforms and structured-document writes, with revision guards."""
+
+from pathlib import Path
+import json
+import uuid
+from sqlalchemy import text
+from database import Asset
+from .access import access, McpError
+from .workspace import media_row
+
+
+async def update(caller, args, session, chat):
+    from agent.v2.workspace import get_workspace_dir
+    from agent.v2.tools.library import save_workspace_file
+    from asset_service import commit_revision, create_asset_from_media
+
+    folder = get_workspace_dir(chat.id, chat.project_id)
+    folder.mkdir(parents=True, exist_ok=True)
+    source = None
+    if args.get("source_ref"):
+        source = await media_row(caller, args["source_ref"], session)
+    if args["format"] == "image":
+        if source is None:
+            raise McpError(
+                "invalid_arguments",
+                "Image transformations require an exact source reference.",
+            )
+        from PIL import Image, ImageOps
+
+        with Image.open(source.file_path) as raw:
+            image = ImageOps.exif_transpose(raw).copy()
+        for operation in args["transforms"]:
+            action = operation["action"]
+            if action == "resize":
+                image = image.resize(
+                    (operation["width"], operation["height"]), Image.Resampling.LANCZOS
+                )
+            elif action == "crop":
+                box = operation["box"]
+                if not (
+                    0 <= box[0] < box[2] <= image.width
+                    and 0 <= box[1] < box[3] <= image.height
+                ):
+                    raise McpError(
+                        "invalid_arguments",
+                        "Crop coordinates must lie inside the image.",
+                    )
+                image = image.crop(box)
+            elif action == "rotate":
+                image = image.rotate(operation["degrees"], expand=True)
+            elif action == "flip_horizontal":
+                image = ImageOps.mirror(image)
+            elif action == "flip_vertical":
+                image = ImageOps.flip(image)
+        path = folder / (uuid.uuid4().hex + ".png")
+        image.save(path)
+    else:
+        extension = {"svg": "svg", "markdown": "md", "layout": "stimmalayout"}[
+            args["format"]
+        ]
+        path = folder / (uuid.uuid4().hex + "." + extension)
+        if args["format"] == "layout":
+            path.mkdir()
+            for entry in args["files"]:
+                relative = Path(entry["name"])
+                if (
+                    relative.is_absolute()
+                    or ".." in relative.parts
+                    or "\\" in entry["name"]
+                ):
+                    raise McpError(
+                        "invalid_arguments",
+                        "Bundle members must have safe relative names.",
+                    )
+                destination = path / relative
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_text(entry["text"])
+            if not (path / "index.html").is_file():
+                raise McpError("invalid_arguments", "A layout requires index.html.")
+        else:
+            content = args["text"]
+            if args["format"] == "svg":
+                from utils.svg_doc import prepare_text
+
+                content, _ = prepare_text(content)
+            path.write_text(content)
+    provenance = {
+        "task_type": "edit",
+        "tool_id": "stimma:mcp-content",
+        "parameters": {"format": args["format"]},
+        "source_media_ids": [source.id] if source else [],
+    }
+    saved = await save_workspace_file(
+        session,
+        str(path),
+        folder,
+        None,
+        provenance=provenance,
+        project_id=chat.project_id,
+        metadata_source="mcp",
+        materialize_asset=False,
+    )
+    if saved.startswith("Error:"):
+        raise McpError("save_failed", "Could not save the edited document.")
+    result = json.loads(saved)
+    # The shared save helper finishes ingestion first. Lock and compare the
+    # current revision in the transaction that acquires the new saved revision.
+    await session.commit()
+    await session.execute(text("BEGIN IMMEDIATE"))
+    if args.get("target_asset_ref"):
+        asset_id = int(access.resolve(caller, args["target_asset_ref"], "asset"))
+        expected = int(
+            access.resolve(caller, args["expected_current_revision"], "revision")
+        )
+        asset = await session.get(Asset, asset_id, populate_existing=True)
+        if not asset or asset.current_revision_id != expected:
+            raise McpError(
+                "revision_conflict",
+                "The Asset changed. The new content has not replaced its current revision.",
+            )
+        revision = await commit_revision(
+            session,
+            asset_id=asset.id,
+            media_id=result["media_id"],
+            parent_revision_id=expected,
+            note="MCP edit",
+        )
+    else:
+        asset = await create_asset_from_media(
+            session, media_id=result["media_id"], origin_type="mcp_edit"
+        )
+        from database import AssetRevision
+
+        revision = await session.get(AssetRevision, asset.current_revision_id)
+    await session.commit()
+    from utils.websocket import ws_manager
+
+    await ws_manager.broadcast(
+        "asset_current_revision_changed",
+        {"asset_id": asset.id, "revision_id": revision.id},
+    )
+    return {
+        "asset_ref": access.ref(caller, "asset", asset.id),
+        "revision_ref": access.ref(caller, "revision", revision.id),
+        "media_ref": access.ref(caller, "media", result["media_id"]),
+    }

--- a/backend/mcp_server/jobs.py
+++ b/backend/mcp_server/jobs.py
@@ -1,0 +1,772 @@
+"""Durable acceptance and shared agent/tool execution; retries never replay work."""
+
+from __future__ import annotations
+import asyncio
+from contextvars import ContextVar
+from datetime import datetime
+import hashlib
+import json
+import uuid
+from sqlalchemy import select, func, text
+from sqlalchemy.ext.asyncio import AsyncSession
+from database import Chat, ChatItem
+from database_registry import get_database_registry
+from core.profile_context import ProfileScope
+from .access import access, Caller, McpError
+from .models import McpOperation
+
+execution_caller: ContextVar[Caller | None] = ContextVar("mcp_execution", default=None)
+execution_chat: ContextVar[int | None] = ContextVar("mcp_execution_chat", default=None)
+_tasks: dict[tuple[str, str], asyncio.Task] = {}
+_locks: dict[str, asyncio.Lock] = {}
+_callers: dict[tuple[str, str], Caller] = {}
+_revoked: set[tuple[str, str]] = set()
+
+
+def check_execution():
+    caller = execution_caller.get()
+    if caller:
+        _, _, stamp = access.stamp(caller.profile_id)
+        if stamp != caller.stamp or caller.key in _revoked:
+            raise McpError(
+                "access_revoked", "External execution authority was revoked."
+            )
+
+
+class AtomicSession(AsyncSession):
+    """Domain helpers may flush, but receipt and mutation commit together."""
+
+    async def commit(self):
+        await self.flush()
+
+    async def finish(self):
+        await super().commit()
+
+
+def lock_for(profile):
+    return _locks.setdefault(profile, asyncio.Lock())
+
+
+def fingerprint(value):
+    return hashlib.sha256(
+        json.dumps(
+            value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        ).encode()
+    ).hexdigest()
+
+
+def envelope(caller, job):
+    return {
+        "job_ref": access.ref(caller, "job", job.id),
+        "state": job.state,
+        "controller_version": job.controller_version,
+        "chat_ref": access.ref(caller, "chat", job.chat_id) if job.chat_id else None,
+        "result": json.loads(job.result_json) if job.result_json else None,
+    }
+
+
+async def receipt(session, operation, key, args, caller):
+    existing = (
+        await session.execute(
+            select(McpOperation).where(
+                McpOperation.operation == operation,
+                McpOperation.request_key == f"{caller.client_id}:{key}",
+            )
+        )
+    ).scalar_one_or_none()
+    if existing and existing.input_hash != fingerprint(args):
+        raise McpError(
+            "request_key_conflict",
+            "Use a new request_key for intentionally changed input.",
+        )
+    return existing
+
+
+async def mutate(caller, name, key, args, fn):
+    db = get_database_registry().get_database(caller.profile_id)
+    async with lock_for(caller.profile_id):
+        async with AtomicSession(db.async_engine, expire_on_commit=False) as session:
+            await session.execute(text("BEGIN IMMEDIATE"))
+            old = await receipt(session, name, key, args, caller)
+            if old:
+                return json.loads(old.result_json)
+            from utils.websocket import defer_broadcasts
+
+            async with defer_broadcasts():
+                value = await fn(session)
+                row = McpOperation(
+                    id=uuid.uuid4().hex,
+                    client_id=caller.client_id,
+                    operation=name,
+                    request_key=f"{caller.client_id}:{key}",
+                    input_hash=fingerprint(args),
+                    input_json=json.dumps(args),
+                    state="succeeded",
+                    result_json=json.dumps(value),
+                )
+                session.add(row)
+                await session.finish()
+            return value
+
+
+async def accept(caller, name, key, args):
+    db = get_database_registry().get_database(caller.profile_id)
+    async with lock_for(caller.profile_id):
+        async with db.async_session_maker() as session:
+            old = await receipt(session, name, key, args, caller)
+            if old:
+                return envelope(caller, old)
+            payload = dict(args)
+            from .workspace import (
+                media_row,
+                tool_descriptor,
+                tool_version,
+                tool_parameters,
+            )
+
+            if name == "content_update" and args.get("source_ref"):
+                source = await media_row(caller, args["source_ref"], session)
+                payload["source_ref"] = access.ref(caller, "media", source.id)
+            if name == "tools_run":
+                if args.get("batch") and args.get("chain"):
+                    raise McpError("invalid_arguments", "Choose a batch or a chain.")
+                payload = json.loads(json.dumps(args))
+                steps = [
+                    {
+                        "tool_ref": args["tool_ref"],
+                        "schema_version": args["schema_version"],
+                        "parameters": p,
+                    }
+                    for p in (payload.get("batch") or [payload["parameters"]])
+                ] + payload.get("chain", [])
+                for step in steps:
+                    _, _, descriptor = await tool_descriptor(caller, step["tool_ref"])
+                    if tool_version(descriptor) != step["schema_version"]:
+                        raise McpError(
+                            "schema_changed",
+                            "Inspect the changed tool before starting new work.",
+                        )
+                    for field, schema in descriptor.parameter_schema.get(
+                        "properties", {}
+                    ).items():
+                        if "x-accept-media" in schema and field in step["parameters"]:
+                            value = step["parameters"][field]
+                            many = isinstance(value, list)
+                            pinned = [
+                                access.ref(
+                                    caller,
+                                    "media",
+                                    (await media_row(caller, ref, session)).id,
+                                )
+                                for ref in (value if many else [value])
+                            ]
+                            step["parameters"][field] = pinned if many else pinned[0]
+                    if not step.get("input_from_previous"):
+                        await tool_parameters(
+                            caller, descriptor, step["parameters"], session
+                        )
+            if (
+                name == "content_update"
+                and args.get("target_asset_ref")
+                and not args.get("expected_current_revision")
+            ):
+                raise McpError(
+                    "invalid_arguments",
+                    "Revising an Asset requires expected_current_revision.",
+                )
+            if args.get("references") or args.get("media_refs"):
+                refs = [
+                    *args.get("references", []),
+                    *[{"ref": ref} for ref in args.get("media_refs", [])],
+                ]
+                pinned = []
+                notes = []
+                for reference in refs:
+                    row = await media_row(caller, reference["ref"], session)
+                    pinned.append(access.ref(caller, "media", row.id))
+                    notes.append(
+                        f"Media {row.id}: {reference.get('role', 'reference')} {reference.get('note', '')}"
+                    )
+                payload["media_refs"] = pinned
+                payload["_reference_notes"] = "\n".join(notes)
+            for skill in args.get("skills", []):
+                from agent.v2.stimpacks import find_skill
+
+                if not find_skill(skill):
+                    raise McpError(
+                        "not_found", "A requested skill is unavailable in this profile."
+                    )
+            # Ordinary chats inherit real project/profile model and tool policy.
+            from database import Project
+
+            project_id = (
+                int(access.resolve(caller, args["project_ref"], "project"))
+                if args.get("project_ref")
+                else None
+            )
+            if project_id and not await session.get(Project, project_id):
+                raise McpError("not_found", "Project is unavailable.")
+            chat = Chat(
+                name=args.get("brief", name)[:80],
+                project_id=project_id,
+                throttle="off",
+                generation_settings=json.dumps({"mcp_origin": caller.client_id}),
+            )
+            if args.get("source_chat"):
+                source_id = int(
+                    access.resolve(caller, args["source_chat"]["chat_ref"], "chat")
+                )
+                checkpoint = int(
+                    access.resolve(
+                        caller, args["source_chat"]["checkpoint_ref"], "chat_item"
+                    )
+                )
+                source = await session.get(Chat, source_id)
+                item = await session.get(ChatItem, checkpoint)
+                if (
+                    not source
+                    or source.deleted_at
+                    or not item
+                    or item.chat_id != source.id
+                ):
+                    raise McpError(
+                        "not_found", "The source chat checkpoint is unavailable."
+                    )
+                chat.original_chatitem_id = checkpoint
+                chat.additional_instructions = source.additional_instructions
+                chat.model_slug = source.model_slug
+                chat.agent_tool_config = source.agent_tool_config
+                chat.project_id = project_id or source.project_id
+            session.add(chat)
+            await session.flush()
+            job = McpOperation(
+                id=uuid.uuid4().hex,
+                client_id=caller.client_id,
+                operation=name,
+                request_key=f"{caller.client_id}:{key}",
+                input_hash=fingerprint(args),
+                input_json=json.dumps(payload),
+                state="queued",
+                chat_id=chat.id,
+            )
+            session.add(job)
+            if name == "agent_start":
+                brief = args["brief"]
+                if payload.get("_reference_notes"):
+                    brief += "\n" + payload["_reference_notes"]
+                if args.get("skills"):
+                    brief += "\nUse these skills: " + ", ".join(args["skills"])
+                if args.get("deliverables"):
+                    brief += "\nDeliverables: " + json.dumps(args["deliverables"])
+                if args.get("interaction") == "unattended":
+                    brief += "\nWork unattended where possible. Park on essential questions and permissions."
+                session.add(
+                    ChatItem(
+                        chat_id=chat.id, item_type="user_message", message_text=brief
+                    )
+                )
+            await session.commit()
+            result = envelope(caller, job)
+        _revoked.discard(caller.key)
+        spawn(caller, job.id)
+        return result
+
+
+def spawn(caller, job_id, response=None, message=None):
+    _callers[caller.profile_id, job_id] = caller
+    _tasks[caller.profile_id, job_id] = asyncio.create_task(
+        run(caller, job_id, response=response, message=message)
+    )
+
+
+async def pending_interaction(session, chat_id):
+    requests = (
+        await session.scalars(
+            select(ChatItem)
+            .where(ChatItem.chat_id == chat_id, ChatItem.item_type == "hitl_request")
+            .order_by(ChatItem.id.desc())
+            .limit(100)
+        )
+    ).all()
+    if not requests:
+        return None
+    responses = (
+        await session.scalars(
+            select(ChatItem).where(
+                ChatItem.chat_id == chat_id,
+                ChatItem.item_type == "hitl_response",
+                ChatItem.id > requests[-1].id,
+            )
+        )
+    ).all()
+    exact = {
+        json.loads(row.item_metadata or "{}").get("_mcp_interaction_id")
+        for row in responses
+    }
+    generic_after = max(
+        (
+            row.id
+            for row in responses
+            if "_mcp_interaction_id" not in json.loads(row.item_metadata or "{}")
+        ),
+        default=0,
+    )
+    return next(
+        (row for row in requests if row.id not in exact and row.id > generic_after),
+        None,
+    )
+
+
+async def run(caller, job_id, *, response=None, message=None):
+    token = execution_caller.set(caller)
+    db = get_database_registry().get_database(caller.profile_id)
+    with ProfileScope(caller.profile_id):
+        try:
+            check_execution()
+            async with db.async_session_maker() as session:
+                job = await session.get(McpOperation, job_id)
+                job.state = "running"
+                await session.commit()
+                chat = await session.get(Chat, job.chat_id)
+                execution_chat.set(chat.id)
+                start_item_id = await session.scalar(
+                    select(func.coalesce(func.max(ChatItem.id), 0)).where(
+                        ChatItem.chat_id == chat.id
+                    )
+                )
+                from .workspace import refresh_custom_tools
+
+                await refresh_custom_tools()
+                args = json.loads(job.input_json)
+                from utils.websocket import ws_manager
+
+                await ws_manager.broadcast("chat_created", {"chat": chat.to_dict()})
+                if response is not None:
+                    from routes.chats import submit_human_response, HITLResponseRequest
+
+                    await submit_human_response(
+                        chat.id, HITLResponseRequest(**response), session
+                    )
+                elif job.operation == "agent_start":
+                    from agent import run_agent
+
+                    refs = [
+                        int(access.resolve(caller, ref, "media"))
+                        for ref in args.get("media_refs", [])
+                    ]
+                    brief = message or args["brief"]
+                    if not message:
+                        if args.get("_reference_notes"):
+                            brief += "\n" + args["_reference_notes"]
+                        if args.get("skills"):
+                            brief += "\nUse these skills: " + ", ".join(args["skills"])
+                        if args.get("deliverables"):
+                            brief += "\nDeliverables: " + json.dumps(
+                                args["deliverables"]
+                            )
+                        if args.get("interaction") == "unattended":
+                            brief += "\nWork unattended where possible. Park on essential questions and permissions."
+                    await run_agent(
+                        chat=chat,
+                        user_message=brief,
+                        session=session,
+                        ws_manager=ws_manager,
+                        selected_media_ids=refs,
+                    )
+                elif job.operation == "tools_run":
+                    from .workspace import execute_tools
+
+                    job.result_json = json.dumps(
+                        await execute_tools(caller, args, session, chat, job)
+                    )
+                elif job.operation == "content_update":
+                    from .content import update
+
+                    job.result_json = json.dumps(
+                        await update(caller, args, session, chat)
+                    )
+                elif job.operation.startswith("bound:"):
+                    from .operations import FAMILIES
+
+                    _, family, action = job.operation.split(":", 2)
+                    binding = FAMILIES[family][1][action]
+                    value = await binding.run(caller, args, session)
+                    job.result_json = json.dumps(value)
+                elif job.operation == "flows_run":
+                    from .workspace import execute_flow
+
+                    job.result_json = json.dumps(
+                        await execute_flow(caller, args, session, chat)
+                    )
+                check_execution()
+                await session.refresh(job, ["state"])
+                if job.state not in ("cancelled", "control_changed"):
+                    pending = await pending_interaction(session, chat.id)
+                    failed = await session.scalar(
+                        select(ChatItem.id)
+                        .where(
+                            ChatItem.chat_id == chat.id,
+                            ChatItem.id > start_item_id,
+                            ChatItem.item_type == "error",
+                        )
+                        .limit(1)
+                    )
+                    partial_failure = (
+                        job.result_json
+                        and any(
+                            i.get("state") in ("failed", "interrupted")
+                            for i in json.loads(job.result_json).get("items", [])
+                            if isinstance(i, dict)
+                        )
+                        if job.operation == "tools_run"
+                        else False
+                    )
+                    job.state = (
+                        "failed"
+                        if failed or partial_failure
+                        else "input_required"
+                        if pending
+                        else "succeeded"
+                    )
+                    job.updated_at = datetime.utcnow()
+                    await session.commit()
+        except asyncio.CancelledError:
+            await set_state(caller, job_id, "cancelled")
+        except Exception as exc:
+            code = exc.code if isinstance(exc, McpError) else "execution_failed"
+            # No raw provider exceptions, prompts, paths or credentials in MCP errors.
+            await set_state(
+                caller,
+                job_id,
+                "failed",
+                {
+                    "code": code,
+                    "message": "Execution stopped. Inspect the chat for details.",
+                },
+            )
+        finally:
+            execution_caller.reset(token)
+            _tasks.pop((caller.profile_id, job_id), None)
+            if "job" in locals() and job.state != "input_required":
+                _callers.pop((caller.profile_id, job_id), None)
+
+
+async def set_state(caller, job_id, state, result=None):
+    db = get_database_registry().get_database(caller.profile_id)
+    async with db.async_session_maker() as session:
+        job = await session.get(McpOperation, job_id)
+        if job and job.state != "control_changed":
+            job.state, job.updated_at = state, datetime.utcnow()
+            if result:
+                job.result_json = json.dumps(result)
+            await session.commit()
+
+
+async def get(caller, job_ref, after=0):
+    job_id = access.resolve(caller, job_ref, "job")
+    db = get_database_registry().get_database(caller.profile_id)
+    async with db.async_session_maker() as session:
+        job = await session.get(McpOperation, job_id)
+        if not job or job.deleted_at:
+            raise McpError("not_found", "Job is unavailable.")
+        if (
+            job.state in ("queued", "running", "input_required")
+            and (caller.profile_id, job_id) not in _callers
+        ):
+            job.state = "interrupted"
+            job.result_json = json.dumps(
+                {
+                    "code": "execution_outcome_unknown",
+                    "message": "The backend restarted. Inspect retained outputs; work was not replayed.",
+                }
+            )
+            await session.commit()
+        output = envelope(caller, job)
+        if job.chat_id:
+            from .operations import present
+
+            items = list(
+                (
+                    await session.scalars(
+                        select(ChatItem)
+                        .where(
+                            ChatItem.chat_id == job.chat_id,
+                            ChatItem.id > after,
+                            ChatItem.item_type.in_(
+                                [
+                                    "user_message",
+                                    "assistant_message",
+                                    "media_display",
+                                    "hitl_request",
+                                    "hitl_response",
+                                    "error",
+                                ]
+                            ),
+                        )
+                        .order_by(ChatItem.id)
+                        .limit(100)
+                    )
+                ).all()
+            )
+            output["events"] = [
+                present(
+                    caller,
+                    {
+                        "id": i.id,
+                        "type": i.item_type,
+                        "text": i.message_text,
+                        "show_role": i.show_role,
+                        "asset_ids": json.loads(i.asset_ids or "[]"),
+                        "media_ids": json.loads(i.media_ids or "[]"),
+                        "metadata": json.loads(i.item_metadata)
+                        if i.item_metadata
+                        else None,
+                    },
+                    "chat_item",
+                )
+                for i in items
+            ]
+            output["next_cursor"] = items[-1].id if items else after
+            pending = await pending_interaction(session, job.chat_id)
+            if pending and job.state not in (
+                "cancelled",
+                "failed",
+                "interrupted",
+                "control_changed",
+            ):
+                output["state"] = "input_required"
+                output["interaction"] = {
+                    "ref": access.ref(caller, "interaction", pending.id),
+                    "version": 1,
+                    "request": present(
+                        caller, json.loads(pending.item_metadata or "{}")
+                    ),
+                }
+        return output
+
+
+async def control(
+    caller, job_ref, version, key, message=None, interaction_ref=None, response=None
+):
+    job_id = access.resolve(caller, job_ref, "job")
+    args = {
+        "job_ref": job_ref,
+        "version": version,
+        "message": message,
+        "interaction_ref": interaction_ref,
+        "response": response,
+    }
+    db = get_database_registry().get_database(caller.profile_id)
+    async with lock_for(caller.profile_id):
+        async with db.async_session_maker() as session:
+            old = await receipt(session, "job_control", key, args, caller)
+            if old:
+                return json.loads(old.result_json)
+            job = await session.get(McpOperation, job_id)
+            if not job or job.deleted_at:
+                raise McpError("not_found", "Job is unavailable.")
+            if job.controller_version != version or job.state in (
+                "control_changed",
+                "cancelled",
+                "interrupted",
+            ):
+                raise McpError(
+                    "control_changed",
+                    "Control has changed. Retrieve the job before continuing.",
+                )
+            pending = await pending_interaction(session, job.chat_id)
+            if interaction_ref:
+                interaction_id = int(
+                    access.resolve(caller, interaction_ref, "interaction")
+                )
+                if not pending or pending.id != interaction_id:
+                    raise McpError(
+                        "control_changed",
+                        "This question has already been answered or replaced.",
+                    )
+            elif pending:
+                raise McpError(
+                    "input_required", "Answer the outstanding interaction first."
+                )
+            active = _tasks.get((caller.profile_id, job_id))
+            inprocess = (
+                json.loads(pending.item_metadata or "{}")
+                .get("v2_tool_args", {})
+                .get("_inprocess_request_id")
+                if pending
+                else None
+            )
+            if inprocess:
+                from agent.v2.tool_permission_gate import _PENDING
+
+                future = _PENDING.get(inprocess)
+                if future is None or future.done():
+                    raise McpError(
+                        "control_changed",
+                        "This question is no longer waiting for an answer.",
+                    )
+            if active and not active.done() and not inprocess:
+                raise McpError(
+                    "job_running", "Wait for the current turn before continuing."
+                )
+            if message and job.operation != "agent_start":
+                raise McpError(
+                    "not_delegated",
+                    "Only delegated agent jobs accept conversation follow-ups.",
+                )
+            if message:
+                session.add(
+                    ChatItem(
+                        chat_id=job.chat_id,
+                        item_type="user_message",
+                        message_text=message,
+                    )
+                )
+            job.controller_version += 1
+            job.client_id = caller.client_id
+            job.state = "running" if inprocess else "queued"
+            result = envelope(caller, job)
+            session.add(
+                McpOperation(
+                    id=uuid.uuid4().hex,
+                    client_id=caller.client_id,
+                    operation="job_control",
+                    request_key=f"{caller.client_id}:{key}",
+                    input_hash=fingerprint(args),
+                    input_json=json.dumps(args),
+                    state="succeeded",
+                    result_json=json.dumps(result),
+                )
+            )
+            await session.commit()
+            if inprocess:
+                from agent.v2.tool_permission_gate import resolve_pending_permission
+
+                if not resolve_pending_permission(inprocess, response):
+                    raise McpError(
+                        "execution_outcome_unknown",
+                        "The waiting execution is no longer available.",
+                    )
+                session.add(
+                    ChatItem(
+                        chat_id=job.chat_id,
+                        item_type="hitl_response",
+                        item_metadata=json.dumps(
+                            {**response, "_mcp_interaction_id": pending.id}
+                        ),
+                    )
+                )
+                await session.commit()
+            else:
+                _revoked.discard(caller.key)
+                spawn(caller, job.id, response=response, message=message)
+            return result
+
+
+async def cancel(caller, job_ref):
+    job_id = access.resolve(caller, job_ref, "job")
+    db = get_database_registry().get_database(caller.profile_id)
+    async with db.async_session_maker() as session:
+        job = await session.get(McpOperation, job_id)
+        if not job:
+            raise McpError("not_found", "Job is unavailable.")
+        if job.state == "control_changed":
+            raise McpError("control_changed", "The desktop controls this chat now.")
+        if job.state in ("succeeded", "failed", "cancelled", "interrupted"):
+            return envelope(caller, job)
+        task = _tasks.get((caller.profile_id, job_id))
+        if task:
+            task.cancel()
+        job.state = "cancelled"
+        job.controller_version += 1
+        await session.commit()
+        return envelope(caller, job)
+
+
+async def revoke(profile_id, client_id=None):
+    access.lock(profile_id, client_id)
+    db = get_database_registry().get_database(profile_id)
+    async with db.async_session_maker() as session:
+        query = select(McpOperation).where(
+            McpOperation.state.in_(["queued", "running", "input_required"])
+        )
+        if client_id:
+            query = query.where(McpOperation.client_id == client_id)
+        for job in (await session.scalars(query)).all():
+            _revoked.add((profile_id, job.client_id))
+            task = _tasks.get((profile_id, job.id))
+            if task:
+                task.cancel()
+            job.state = "cancelled"
+            job.controller_version += 1
+        await session.commit()
+
+
+async def takeover(profile_id, chat_id):
+    """Desktop user input owns the chat from this point; stale MCP replies fail."""
+    db = get_database_registry().get_database(profile_id)
+    async with lock_for(profile_id):
+        async with db.async_session_maker() as session:
+            rows = await session.scalars(
+                select(McpOperation).where(
+                    McpOperation.chat_id == chat_id,
+                    McpOperation.operation.in_(
+                        ["agent_start", "tools_run", "flows_run"]
+                    ),
+                )
+            )
+            for job in rows:
+                job.controller_version += 1
+                job.state = "control_changed"
+                task = _tasks.get((profile_id, job.id))
+                if task:
+                    task.cancel()
+            await session.commit()
+
+
+async def watch_revocations():
+    """PIN/config changes revoke parked work as well as future dispatches."""
+    while True:
+        await asyncio.sleep(1)
+        for key, caller in list(_callers.items()):
+            try:
+                _, _, stamp = access.stamp(caller.profile_id)
+                if stamp == caller.stamp:
+                    continue
+            except (McpError, KeyError, ValueError):
+                pass
+            try:
+                await revoke(caller.profile_id, caller.client_id)
+            except (McpError, KeyError, ValueError):
+                task = _tasks.get(key)
+                if task:
+                    task.cancel()
+            _callers.pop(key, None)
+
+
+async def retry(caller, job_ref, key):
+    db = get_database_registry().get_database(caller.profile_id)
+    async with db.async_session_maker() as session:
+        old = await session.get(McpOperation, access.resolve(caller, job_ref, "job"))
+        if not old or old.operation != "tools_run" or old.state != "failed":
+            raise McpError(
+                "retry_unavailable",
+                "Only known failed tool items can be retried. Unknown outcomes need review.",
+            )
+        args = json.loads(old.input_json)
+        if args.get("chain"):
+            raise McpError(
+                "retry_unavailable",
+                "Inspect the retained chain outputs and start the failed step explicitly.",
+            )
+        items = json.loads(old.result_json or "{}").get("items", [])
+        failed = [i["index"] for i in items if i.get("state") == "failed"]
+        if not failed:
+            raise McpError(
+                "retry_unavailable",
+                "There are no confirmed failed dispatches to retry.",
+            )
+        batches = args.get("batch") or [args["parameters"]]
+        args["batch"] = [batches[i] for i in failed]
+        args["_retry_of"] = job_ref
+    return await accept(caller, "tools_run", key, args)

--- a/backend/mcp_server/logging.py
+++ b/backend/mcp_server/logging.py
@@ -1,0 +1,21 @@
+"""Keep SDK diagnostics categorical: SDK debug reprs can contain access_open PINs."""
+
+import logging
+
+
+class TransportLogFilter(logging.Filter):
+    def filter(self, record):
+        record.msg = "MCP transport event (%s)"
+        record.args = (record.levelname,)
+        record.exc_info = None
+        record.exc_text = None
+        record.stack_info = None
+        return True
+
+
+def protect_sdk_logs():
+    for name in list(logging.Logger.manager.loggerDict):
+        if name == "mcp" or name.startswith("mcp."):
+            logger = logging.getLogger(name)
+            if not any(isinstance(f, TransportLogFilter) for f in logger.filters):
+                logger.addFilter(TransportLogFilter())

--- a/backend/mcp_server/models.py
+++ b/backend/mcp_server/models.py
@@ -1,0 +1,37 @@
+"""Durable MCP connection identities and operation receipts, per profile DB."""
+
+from datetime import datetime
+from sqlalchemy import Column, DateTime, Integer, String, Text, UniqueConstraint
+from database import Base
+from core.profile_context import get_current_profile
+
+
+class McpClient(Base):
+    __tablename__ = "mcp_clients"
+    id = Column(String, primary_key=True)
+    name = Column(String, nullable=False)
+    profile_id = Column(String, nullable=False, default=get_current_profile)
+    credential_hash = Column(String, nullable=False, unique=True)
+    installation = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    deleted_at = Column(DateTime, nullable=True)
+
+
+class McpOperation(Base):
+    __tablename__ = "mcp_operations"
+    id = Column(String, primary_key=True)
+    client_id = Column(String, nullable=False)
+    operation = Column(String, nullable=False)
+    request_key = Column(String, nullable=False)
+    input_hash = Column(String, nullable=False)
+    state = Column(String, nullable=False, default="queued")
+    input_json = Column(Text, nullable=False)
+    result_json = Column(Text, nullable=True)
+    chat_id = Column(Integer, nullable=True)
+    controller_version = Column(Integer, nullable=False, default=1)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    deleted_at = Column(DateTime, nullable=True)
+    __table_args__ = (
+        UniqueConstraint("operation", "request_key", name="uq_mcp_request"),
+    )

--- a/backend/mcp_server/operations.py
+++ b/backend/mcp_server/operations.py
@@ -1,0 +1,661 @@
+"""Typed, curated domain operations. No REST passthrough or arbitrary dispatch."""
+
+from __future__ import annotations
+import copy
+import importlib
+import inspect
+import json
+from dataclasses import dataclass
+from typing import Any, get_type_hints
+from fastapi.encoders import jsonable_encoder
+from pydantic import BaseModel, ConfigDict, create_model
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
+from .access import access, McpError
+
+ACCESS_HELP = " If locked, use access_open with a PIN explicitly supplied by the user; never guess. Retry a lost mutation response with the same request_key."
+
+ID_KINDS = {
+    "asset_id": "asset",
+    "asset_ids": "asset",
+    "source_asset_id": "asset",
+    "media_id": "media",
+    "media_ids": "media",
+    "selected_media_ids": "media",
+    "primary_media_id": "media",
+    "parent_revision_id": "revision",
+    "source_id": "media",
+    "target_id": "media",
+    "from_chatitem_id": "chat_item",
+    "source_media_id": "media",
+    "target_media_id": "media",
+    "excluded_marker_ids": "marker",
+    "excluded_tag_ids": "tag",
+    "excluded_project_ids": "project",
+    "revision_id": "revision",
+    "current_revision_id": "revision",
+    "expected_revision_id": "revision",
+    "board_id": "board",
+    "board_ids": "board",
+    "project_id": "project",
+    "project_ids": "project",
+    "chat_id": "chat",
+    "flow_id": "flow",
+    "preset_id": "preset",
+    "view_id": "view",
+    "section_id": "section",
+    "section_ids": "section",
+    "target_section_id": "section",
+    "board_section_id": "section",
+    "destination_section_id": "section",
+    "cover_asset_id": "asset",
+    "cover_media_id": "media",
+    "remove_tag_ids": "tag",
+    "marker_id": "marker",
+    "marker_ids": "marker",
+    "tag_id": "tag",
+    "tag_ids": "tag",
+    "user_tool_id": "custom_tool",
+    "item_id": "chat_item",
+    "chat_item_id": "chat_item",
+}
+PRIVATE_FIELDS = {
+    "_mcp_interaction_id",
+    "_inprocess_request_id",
+    "file_path",
+    "folder_path",
+    "source_path",
+    "workspace_path",
+    "workspace_dir",
+    "pin",
+    "pin_hash",
+    "credential_hash",
+    "agent_tool_config",
+    "tool_config",
+    "folders",
+    "excluded_folders",
+    "execution_state",
+    "original_chatitem_id",
+    "generation_settings",
+    "raw_metadata",
+    "lineage_trace",
+    "llm_trace",
+    "thinking",
+    "reasoning",
+}
+NESTED_KINDS = {
+    "asset": "asset",
+    "revision": "revision",
+    "board": "board",
+    "project": "project",
+    "chat": "chat",
+    "flow": "flow",
+    "preset": "preset",
+    "assets": "asset",
+    "revisions": "revision",
+    "media": "media",
+    "boards": "board",
+    "sections": "section",
+    "projects": "project",
+    "chats": "chat",
+    "flows": "flow",
+    "presets": "preset",
+    "markers": "marker",
+    "tags": "tag",
+}
+
+
+def present(caller, value, kind=None):
+    value = jsonable_encoder(value)
+    if isinstance(value, list):
+        return [present(caller, item, kind) for item in value]
+    if not isinstance(value, dict):
+        return value
+    output = {}
+    if value.get("updated_at") is not None:
+        output["version"] = value["updated_at"]
+    for key, item in value.items():
+        if key in ("generation_metadata", "item_metadata") and isinstance(item, str):
+            try:
+                item = json.loads(item)
+            except ValueError:
+                continue
+        if key in PRIVATE_FIELDS or key.endswith("_path") or key.endswith("_dir"):
+            continue
+        entity = ID_KINDS.get(key) or (kind if key == "id" else None)
+        if entity and item is not None:
+            if isinstance(item, list):
+                output[key] = [access.ref(caller, entity, ident) for ident in item]
+            elif isinstance(item, (str, int)):
+                output[key] = access.ref(caller, entity, item)
+            else:
+                output[key] = present(caller, item, entity)
+        else:
+            output[key] = present(caller, item, NESTED_KINDS.get(key, kind))
+    return output
+
+
+def decode(caller, value, key=None, schema=None, definitions=None):
+    schema, definitions = schema or {}, definitions or {}
+    if "$ref" in schema:
+        schema = definitions[schema["$ref"].rsplit("/", 1)[-1]]
+    if "anyOf" in schema:
+        schema = next((s for s in schema["anyOf"] if s.get("type") != "null"), {})
+        if "$ref" in schema:
+            schema = definitions[schema["$ref"].rsplit("/", 1)[-1]]
+    if isinstance(value, dict):
+        return {
+            k: decode(
+                caller, v, k, schema.get("properties", {}).get(k, {}), definitions
+            )
+            for k, v in value.items()
+        }
+    kind = ID_KINDS.get(key)
+    if kind and value is not None:
+
+        def resolve(ref):
+            identifier = access.resolve(caller, ref, kind)
+            return int(identifier) if identifier.isdigit() else identifier
+
+        result = (
+            [resolve(v) for v in value] if isinstance(value, list) else resolve(value)
+        )
+        if schema.get("type") == "string":
+            return (
+                ",".join(map(str, result)) if isinstance(result, list) else str(result)
+            )
+        return result
+    if isinstance(value, list):
+        return [
+            decode(caller, v, schema=schema.get("items", {}), definitions=definitions)
+            for v in value
+        ]
+    return value
+
+
+def public_schema(schema):
+    schema = copy.deepcopy(schema)
+
+    def visit(node, key=None):
+        if not isinstance(node, dict):
+            return
+        if key in ID_KINDS:
+            nullable = any(x.get("type") == "null" for x in node.get("anyOf", []))
+            many = (
+                node.get("type") == "array"
+                or key.endswith("_ids")
+                or any(x.get("type") == "array" for x in node.get("anyOf", []))
+            )
+            node.clear()
+            node.update(
+                {"type": "array", "items": {"type": "string"}, "maxItems": 200}
+                if many
+                else {"type": ["string", "null"] if nullable else "string"}
+            )
+            node["description"] = (
+                f"Opaque {ID_KINDS[key]} reference returned by Stimma; never a numeric database ID."
+            )
+            return
+        if node.get("type") == "object" and "properties" in node:
+            node["additionalProperties"] = False
+            for k in list(node["properties"]):
+                if k in PRIVATE_FIELDS or (
+                    node.get("title") == "FlowUpdateRequest" and k == "inputs"
+                ):
+                    node["properties"].pop(k)
+                    if k in node.get("required", []):
+                        node["required"].remove(k)
+                else:
+                    visit(node["properties"][k], k)
+        for k in ("$defs",):
+            for child in node.get(k, {}).values():
+                visit(child)
+        for k in ("anyOf", "oneOf", "allOf"):
+            for child in node.get(k, []):
+                visit(child, key)
+        if isinstance(node.get("items"), dict):
+            visit(node["items"])
+
+    visit(schema)
+    return schema
+
+
+@dataclass
+class Binding:
+    module: str
+    function: str
+    kind: str | None
+    write: bool = False
+    _model: Any = None
+    _fn: Any = None
+
+    def load(self):
+        if self._model:
+            return
+        self._fn = getattr(
+            importlib.import_module("routes." + self.module), self.function
+        )
+        types = get_type_hints(self._fn)
+        fields = {}
+        for name, param in inspect.signature(self._fn).parameters.items():
+            if name == "session":
+                continue
+            annotation = types.get(name, Any)
+            default = param.default
+            if default is inspect.Parameter.empty:
+                default = ...
+            if isinstance(default, FieldInfo):
+                default = copy.copy(default)
+            fields[name] = annotation, default
+        self._model = create_model(
+            "Mcp_" + self.function, __config__=ConfigDict(extra="forbid"), **fields
+        )
+
+    def schema(self):
+        self.load()
+        schema = public_schema(self._model.model_json_schema())
+        if self.function == "browse_assets":
+            for name in ("source_refs", "excluded_source_refs"):
+                schema["properties"][name] = {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "maxItems": 100,
+                }
+        if self.function == "restore_asset_revision_route":
+            schema["properties"]["expected_current_revision"] = {"type": "string"}
+            schema.setdefault("required", []).append("expected_current_revision")
+        if self.function == "update_flow_program":
+            schema["properties"]["program_version"] = {
+                "type": "string",
+                "description": "SHA256 version returned by flows_get program.",
+            }
+            schema.setdefault("required", []).append("program_version")
+        return schema
+
+    async def run(self, caller, args, session):
+        self.load()
+        args = dict(args)
+        if self.function == "browse_assets":
+            from config import get_settings
+
+            profile = get_settings().get_profile(caller.profile_id)
+            for public, internal in [
+                ("source_refs", "folders"),
+                ("excluded_source_refs", "excluded_folders"),
+            ]:
+                if public in args:
+                    import hashlib
+
+                    folders = {
+                        hashlib.sha256(folder.path.encode()).hexdigest(): folder.path
+                        for folder in profile.folders
+                    }
+                    identifiers = [
+                        access.resolve(caller, ref, "source")
+                        for ref in args.pop(public)
+                    ]
+                    if any(identifier not in folders for identifier in identifiers):
+                        raise McpError("not_found", "Source is unavailable.")
+                    args[internal] = ",".join(
+                        folders[identifier] for identifier in identifiers
+                    )
+        if self.function == "restore_asset_revision_route":
+            from database import Asset
+
+            asset_id = int(access.resolve(caller, args["asset_id"], "asset"))
+            expected = int(
+                access.resolve(
+                    caller, args.pop("expected_current_revision"), "revision"
+                )
+            )
+            asset = await session.get(Asset, asset_id)
+            if not asset or asset.current_revision_id != expected:
+                raise McpError(
+                    "revision_conflict",
+                    "The current revision changed; read it again before restoring.",
+                )
+        if self.function == "update_flow_program":
+            import hashlib
+            from flow_runtime import get_flow_program_path
+            from database import Flow
+
+            flow_id = int(access.resolve(caller, args["flow_id"], "flow"))
+            flow = await session.get(Flow, flow_id)
+            if not flow or flow.execution_state == "running":
+                raise McpError(
+                    "control_changed",
+                    "Pause the Flow in Stimma before editing its program.",
+                )
+            expected = args.pop("program_version")
+            path = get_flow_program_path(flow_id)
+            actual = hashlib.sha256(
+                (path.read_text() if path.exists() else "").encode()
+            ).hexdigest()
+            if actual != expected:
+                raise McpError(
+                    "revision_conflict",
+                    "The Flow program changed. Read it again before editing.",
+                )
+        original = self._model.model_json_schema()
+        parsed = self._model.model_validate(
+            decode(caller, args, schema=original, definitions=original.get("$defs", {}))
+        )
+        kwargs = {name: getattr(parsed, name) for name in type(parsed).model_fields}
+        if "session" in inspect.signature(self._fn).parameters:
+            kwargs["session"] = session
+        return present(caller, await self._fn(**kwargs), self.kind)
+
+
+# Each action is explicitly selected and independently schema-validated. Settings,
+# filesystem, provider credentials and raw execution routes are never registered.
+FAMILIES: dict[str, tuple[str, dict[str, Binding]]] = {}
+
+
+def family(name, description, module, kind, reads=(), writes=()):
+    bindings = {}
+    for write, entries in [(False, reads), (True, writes)]:
+        for action, fn in entries:
+            bindings[action] = Binding(module, fn, kind, write)
+    FAMILIES[name] = description, bindings
+
+
+family(
+    "boards_get",
+    "Inspect boards, sections and membership. Removing membership preserves Assets.",
+    "boards",
+    "board",
+    [("list", "get_boards"), ("detail", "get_board")],
+)
+family(
+    "boards_update",
+    "Organize boards and sections with explicit membership operations.",
+    "boards",
+    "board",
+    writes=[
+        ("create", "create_board"),
+        ("update", "update_board"),
+        ("trash", "delete_board"),
+        ("restore", "restore_board"),
+        ("section_create", "create_board_section"),
+        ("section_update", "update_board_section"),
+        ("section_delete", "delete_board_section"),
+        ("section_reorder", "reorder_board_sections"),
+        ("add", "add_board_items"),
+        ("remove", "bulk_remove_board_items"),
+        ("move", "bulk_move_board_items"),
+    ],
+)
+family(
+    "projects_get",
+    "Inspect projects and their workspace context.",
+    "projects",
+    "project",
+    [("list", "list_projects"), ("detail", "get_project")],
+)
+family(
+    "projects_update",
+    "Create or edit project context and model choices. Tool permissions cannot be widened.",
+    "projects",
+    "project",
+    writes=[
+        ("create", "create_project"),
+        ("update", "update_project"),
+        ("delete", "delete_project"),
+    ],
+)
+family(
+    "saved_views_get",
+    "Read saved browser filters.",
+    "saved_views",
+    "view",
+    [("list", "get_saved_views"), ("detail", "get_saved_view")],
+)
+family(
+    "saved_views_update",
+    "Save and organize browser filter definitions.",
+    "saved_views",
+    "view",
+    writes=[
+        ("create", "create_saved_view"),
+        ("update", "update_saved_view"),
+        ("delete", "delete_saved_view"),
+        ("reorder", "reorder_saved_view"),
+    ],
+)
+family(
+    "presets_get",
+    "Inspect saved tool settings without executing them or changing usage.",
+    "presets",
+    "preset",
+    [("list", "list_presets"), ("detail", "get_preset"), ("stats", "get_preset_stats")],
+)
+family(
+    "presets_update",
+    "Create, edit, duplicate or remove tool presets.",
+    "presets",
+    "preset",
+    writes=[
+        ("create", "create_preset"),
+        ("update", "update_preset"),
+        ("delete", "delete_preset"),
+        ("duplicate", "duplicate_preset"),
+    ],
+)
+family(
+    "revisions_list",
+    "Inspect immutable saved revisions of an Asset.",
+    "assets",
+    "revision",
+    [("list", "list_asset_revisions")],
+)
+family(
+    "revisions_restore",
+    "Restore a historical revision as the current saved revision.",
+    "assets",
+    "asset",
+    writes=[("restore", "restore_asset_revision_route")],
+)
+family(
+    "assets_trash",
+    "Move Assets to Trash without immediately deleting their files.",
+    "assets",
+    "asset",
+    writes=[("trash", "trash_assets")],
+)
+family(
+    "assets_restore",
+    "Restore trashed Assets.",
+    "assets",
+    "asset",
+    writes=[("restore", "restore_assets")],
+)
+family(
+    "assets_update",
+    "Update Asset expiration, project membership or explicitly promote retained contextual media.",
+    "assets",
+    "asset",
+    writes=[
+        ("clear_expiration", "clear_asset_expiration"),
+        ("add_project", "add_assets_to_project"),
+        ("remove_project", "remove_asset_from_project"),
+        ("promote", "promote_contextual_media"),
+    ],
+)
+family(
+    "markers_update",
+    "Explicit marker assignment or removal. Inspect the catalog first; unknown markers are not created.",
+    "assets",
+    "asset",
+    writes=[("assign", "bulk_asset_markers")],
+)
+family(
+    "tags_update",
+    "Add or remove user tags on Assets.",
+    "assets",
+    "asset",
+    writes=[("assign", "bulk_asset_tags")],
+)
+family(
+    "containers_get",
+    "Inspect container members, preserving linked Asset versus embedded Media semantics.",
+    "assets",
+    "asset",
+    [("members", "container_member_summary")],
+)
+family(
+    "containers_update",
+    "Promote container members or explode the container; exploding trashes the container.",
+    "assets",
+    "asset",
+    writes=[
+        ("promote", "promote_container_members"),
+        ("explode", "explode_container_asset"),
+    ],
+)
+family(
+    "assets_facets",
+    "Count matches by browser facet without an agent.",
+    "assets",
+    None,
+    [("counts", "get_asset_filter_counts"), ("keywords", "get_asset_top_keywords")],
+)
+family(
+    "contextual_media_get",
+    "Inspect retained chat, Flow and editor intermediates without promoting them into All Assets.",
+    "assets",
+    "media",
+    [("list", "list_contextual_media")],
+)
+family(
+    "chats_get",
+    "Read visible chat history or list chats. Execution and private model traces are separate.",
+    "chats",
+    "chat",
+    [("list", "list_chats"), ("detail", "get_chat")],
+)
+family(
+    "chats_update",
+    "Manage chat metadata or fork an existing chat; these operations do not start the agent.",
+    "chats",
+    "chat",
+    writes=[
+        ("create", "create_chat"),
+        ("update", "update_chat"),
+        ("fork", "fork_chat"),
+        ("branch", "branch_chat"),
+        ("trash", "delete_chat"),
+        ("restore", "restore_chat"),
+    ],
+)
+family(
+    "flows_get",
+    "Inspect reusable Flow definitions. Use flows_run for known workflows or delegate authoring to agent_start.",
+    "flows",
+    "flow",
+    [
+        ("list", "list_flows"),
+        ("detail", "get_flow"),
+        ("program", "get_flow_program"),
+        ("equations", "list_equations"),
+        ("trace", "get_equation_trace"),
+    ],
+)
+family(
+    "flows_update",
+    "Create, fork or edit a reusable Flow. Program changes can invalidate and resume computation.",
+    "flows",
+    "flow",
+    writes=[
+        ("create", "create_flow"),
+        ("fork", "fork_flow"),
+        ("update", "update_flow"),
+        ("program", "update_flow_program"),
+        ("trash", "delete_flow"),
+        ("restore", "restore_flow"),
+    ],
+)
+family(
+    "custom_tools_get",
+    "Inspect profile-owned tools frozen from Flows.",
+    "user_tools",
+    "custom_tool",
+    [
+        ("list", "list_user_tools"),
+        ("detail", "get_user_tool"),
+        ("defaults", "freeze_defaults"),
+    ],
+)
+family(
+    "custom_tools_update",
+    "Freeze a Flow or edit, refresh and remove its custom tool definition.",
+    "user_tools",
+    "custom_tool",
+    writes=[
+        ("freeze", "freeze_flow"),
+        ("update", "patch_user_tool"),
+        ("resync", "resync_user_tool"),
+        ("delete", "delete_user_tool"),
+    ],
+)
+
+
+def descriptors():
+    from mcp.types import Tool, ToolAnnotations
+
+    result = []
+    for name, (description, variants) in FAMILIES.items():
+        schemas = []
+        definitions = {}
+        write = any(b.write for b in variants.values())
+        for action, binding in variants.items():
+            schema = binding.schema()
+            definitions.update(schema.pop("$defs", {}))
+            schema["properties"]["action"] = {"const": action, "type": "string"}
+            schema.setdefault("required", []).append("action")
+            if binding.write:
+                schema["properties"]["request_key"] = {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                }
+                schema["required"].append("request_key")
+            schemas.append(schema)
+        result.append(
+            Tool(
+                name=name,
+                description=description + ACCESS_HELP,
+                inputSchema={"type": "object", "oneOf": schemas, "$defs": definitions},
+                annotations=ToolAnnotations(
+                    readOnlyHint=not write,
+                    destructiveHint=write,
+                    idempotentHint=write,
+                    openWorldHint=False,
+                ),
+            )
+        )
+    return result
+
+
+family(
+    "assets_delete_permanently",
+    "Preview or permanently delete trashed Assets using Stimma’s durable deletion service. Deleting files is irreversible.",
+    "assets",
+    "asset",
+    [("preview", "get_asset_deletion_preview")],
+    [("delete", "permanently_delete_assets")],
+)
+family(
+    "share_publish",
+    "Explicitly publish selected media using Stimma’s existing identity and content checks. Never needed for ordinary file delivery.",
+    "share",
+    "media",
+    writes=[("publish", "share_media")],
+)
+
+family(
+    "containers_create",
+    "Create a set of linked Assets or embedded exact Media. Specify exactly one member list.",
+    "media",
+    "asset",
+    writes=[("create", "create_set_from_media")],
+)

--- a/backend/mcp_server/selections.py
+++ b/backend/mcp_server/selections.py
@@ -1,0 +1,81 @@
+"""Stable all-match selections. Membership uses Assets; payloads pin revisions."""
+
+import json
+import time
+import uuid
+from database import Asset, AssetRevision
+from .models import McpOperation
+from .access import access, McpError
+from .workspace import query_binding
+from .jobs import fingerprint
+
+
+async def create(caller, query, session):
+    targets = []
+    page = 1
+    while True:
+        result = await query_binding.run(
+            caller, {**query, "page": page, "page_size": 200}, session
+        )
+        for item in result["items"]:
+            asset_ref = item.get("asset_id") or item["id"]
+            asset = await session.get(
+                Asset, int(access.resolve(caller, asset_ref, "asset"))
+            )
+            revision = await session.get(AssetRevision, asset.current_revision_id)
+            targets.append(
+                {
+                    "asset_ref": asset_ref,
+                    "revision_ref": access.ref(caller, "revision", revision.id),
+                    "media_ref": access.ref(caller, "media", revision.primary_media_id),
+                }
+            )
+        if len(targets) > 10000:
+            raise McpError(
+                "selection_too_large", "Narrow this query to at most 10,000 Assets."
+            )
+        if len(targets) >= result["total"]:
+            break
+        if not result["items"]:
+            raise McpError(
+                "selection_changed", "The query changed during selection. Try again."
+            )
+        page += 1
+    identifier = uuid.uuid4().hex
+    data = {"targets": targets, "expires_at": time.time() + 86400}
+    session.add(
+        McpOperation(
+            id=identifier,
+            client_id=caller.client_id,
+            operation="selection",
+            request_key=identifier,
+            input_hash=fingerprint(query),
+            input_json=json.dumps(query),
+            state="succeeded",
+            result_json=json.dumps(data),
+        )
+    )
+    await session.commit()
+    return {
+        "selection_ref": access.ref(caller, "selection", identifier),
+        "count": len(targets),
+        "expires_at": data["expires_at"],
+    }
+
+
+async def read(caller, reference, offset, session):
+    identifier = access.resolve(caller, reference, "selection")
+    row = await session.get(McpOperation, identifier)
+    if not row or row.operation != "selection" or row.deleted_at:
+        raise McpError("not_found", "Selection is unavailable.")
+    data = json.loads(row.result_json)
+    if data["expires_at"] < time.time():
+        raise McpError(
+            "selection_expired", "Create a fresh selection before starting new work."
+        )
+    targets = data["targets"]
+    return {
+        "items": targets[offset : offset + 200],
+        "count": len(targets),
+        "next_offset": offset + 200 if offset + 200 < len(targets) else None,
+    }

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -1,0 +1,735 @@
+"""Official MCP SDK transport with an immutable authenticated profile context."""
+
+from __future__ import annotations
+import json
+from contextlib import asynccontextmanager
+from urllib.parse import urlparse
+import jsonschema
+from mcp.server.lowlevel import Server
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.server.transport_security import TransportSecuritySettings
+from mcp.types import Tool, ToolAnnotations, TextContent, CallToolResult
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from core.profile_context import ProfileScope
+from database_registry import get_database_registry
+from .access import access, McpError
+from . import jobs, workspace
+from .operations import descriptors, FAMILIES, ACCESS_HELP
+
+from .logging import protect_sdk_logs
+
+protect_sdk_logs()
+
+server = Server(
+    "Stimma",
+    instructions="Operate the bound creative workspace. Use direct tools for known searches, organization and exact tool execution. Delegate creative judgment or iteration to agent_start. Inspect lineage before reproducing a multi-step result. Poll jobs_get for accepted work; never resubmit to get progress."
+    + ACCESS_HELP,
+)
+manager = StreamableHTTPSessionManager(
+    server,
+    json_response=True,
+    stateless=True,
+    security_settings=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+)
+# The gateway below validates Origin before every request, including file transfer.
+
+
+def obj(properties, required=()):
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": list(required),
+        "additionalProperties": False,
+    }
+
+
+def string(description="", **kw):
+    return {"type": "string", "description": description, **kw}
+
+
+def array(items, maximum=200):
+    return {"type": "array", "items": items, "maxItems": maximum}
+
+
+KEY = string(
+    "Retry identity. Reuse after a lost response; change for intentionally new work.",
+    minLength=1,
+    maxLength=128,
+)
+REF = string("Opaque reference returned by Stimma.")
+TOOLS = {
+    "workspace_get": (
+        "Inspect this connection’s lock status and bound profile.",
+        obj({}),
+        False,
+    ),
+    "access_open": (
+        "Unlock this configured client with the PIN explicitly supplied by the user. Never guess or retry a failed PIN.",
+        obj({"pin": string(maxLength=72)}),
+        True,
+    ),
+    "access_lock": (
+        "Lock this configured client across all its transport sessions and cancel its external jobs.",
+        obj({}),
+        True,
+    ),
+    "chat_history": (
+        "Read visible chat messages and saved media references, with checkpoint references for a deliberate fork.",
+        obj(
+            {"chat_ref": REF, "after": {"type": "integer", "minimum": 0, "default": 0}},
+            ["chat_ref"],
+        ),
+        False,
+    ),
+    "assets_get": (
+        "Inspect exact Assets without changing them.",
+        obj({"refs": array(REF)}, ["refs"]),
+        False,
+    ),
+    "catalog_get": (
+        "Discover marker/tag/source/skill/format catalogs.",
+        obj(
+            {
+                "kind": {
+                    "enum": [
+                        "markers",
+                        "tags",
+                        "sources",
+                        "skills",
+                        "formats",
+                        "saved_views",
+                    ]
+                },
+                "offset": {"type": "integer", "minimum": 0, "default": 0},
+            },
+            ["kind"],
+        ),
+        False,
+    ),
+    "tools_search": (
+        "Find available permitted provider tools by description or task type.",
+        obj(
+            {
+                "query": string(),
+                "task_type": string(),
+                "offset": {"type": "integer", "minimum": 0, "default": 0},
+            }
+        ),
+        False,
+    ),
+    "tools_inspect": (
+        "Inspect a tool’s current input/output schemas and version before executing it.",
+        obj({"tool_ref": REF}, ["tool_ref"]),
+        False,
+    ),
+    "tools_run": (
+        "Run an exact provider tool without the planning agent. Uses normal spend permissions. Returns a durable job; poll jobs_get.",
+        obj(
+            {
+                "tool_ref": REF,
+                "schema_version": string(),
+                "parameters": {"type": "object"},
+                "project_ref": REF,
+                "request_key": KEY,
+            },
+            ["tool_ref", "schema_version", "parameters", "request_key"],
+        ),
+        True,
+    ),
+    "agent_start": (
+        "Delegate creative judgment, technique selection, visual review or iteration to the existing Stimma agent. Creates a visible chat and durable job.",
+        obj(
+            {
+                "brief": string(minLength=1, maxLength=32000),
+                "media_refs": array(REF),
+                "project_ref": REF,
+                "request_key": KEY,
+            },
+            ["brief", "request_key"],
+        ),
+        True,
+    ),
+    "agent_continue": (
+        "Continue the same delegated chat after its current turn. Follow-ups use ordinary permissions.",
+        obj(
+            {
+                "job_ref": REF,
+                "controller_version": {"type": "integer", "minimum": 1},
+                "message": string(minLength=1, maxLength=32000),
+                "request_key": KEY,
+            },
+            ["job_ref", "controller_version", "message", "request_key"],
+        ),
+        True,
+    ),
+    "jobs_get": (
+        "Retrieve job status, visible events and outstanding questions. Polling does not extend PIN unlock.",
+        obj(
+            {"job_ref": REF, "after": {"type": "integer", "minimum": 0, "default": 0}},
+            ["job_ref"],
+        ),
+        False,
+    ),
+    "jobs_cancel": (
+        "Cancel external work. Cancellation is not a rollback or refund.",
+        obj({"job_ref": REF}, ["job_ref"]),
+        True,
+    ),
+    "interaction_respond": (
+        "Answer the exact outstanding question. Put permission questions to the human; this server trusts the connected assistant to relay their answer. No blanket approval.",
+        obj(
+            {
+                "job_ref": REF,
+                "controller_version": {"type": "integer", "minimum": 1},
+                "interaction_ref": REF,
+                "version": {"const": 1},
+                "response": obj(
+                    {
+                        "approved": {"type": "boolean"},
+                        "answer": string(maxLength=32000),
+                        "choice_indices": array({"type": "integer", "minimum": 0}),
+                    }
+                ),
+                "request_key": KEY,
+            },
+            [
+                "job_ref",
+                "controller_version",
+                "interaction_ref",
+                "version",
+                "response",
+                "request_key",
+            ],
+        ),
+        True,
+    ),
+    "media_read": (
+        "See a bounded preview or structured document directly in the tool result. Does not promote media or open an editor.",
+        obj({"ref": REF}, ["ref"]),
+        False,
+    ),
+    "media_export": (
+        "Request an authenticated original or complete bundle download. The local bridge saves it on the assistant’s machine. Never publishes publicly.",
+        obj({"ref": REF}, ["ref"]),
+        False,
+    ),
+    "flows_run": (
+        "Run a known Flow once with its inspected program version. Decisions remain pending until answered; no automatic first-candidate selection.",
+        obj(
+            {
+                "flow_ref": REF,
+                "program_version": string(),
+                "inputs": {"type": "object"},
+                "project_ref": REF,
+                "request_key": KEY,
+            },
+            ["flow_ref", "program_version", "request_key"],
+        ),
+        True,
+    ),
+    "ui_context_get": (
+        "Read the selection explicitly shared from Stimma’s context menu. Returns no ambient desktop state; snapshots expire after ten minutes.",
+        obj({}),
+        False,
+    ),
+    "ui_open": (
+        "Return a profile-aware link to review an entity in Stimma. Does not silently switch a desktop window.",
+        obj({"ref": REF}, ["ref"]),
+        False,
+    ),
+}
+
+# References pin media at acceptance; labels and deliverables become ordinary
+# task context for the existing agent, never an independent planning runtime.
+TOOLS["agent_start"][1]["properties"].update(
+    {
+        "references": array(
+            obj(
+                {
+                    "ref": REF,
+                    "role": string(maxLength=80),
+                    "note": string(maxLength=2000),
+                },
+                ["ref"],
+            )
+        ),
+        "skills": array(string(), 50),
+        "deliverables": obj(
+            {
+                "kind": string(maxLength=80),
+                "count": {"type": "integer", "minimum": 1, "maximum": 1000},
+                "width": {"type": "integer", "minimum": 1},
+                "height": {"type": "integer", "minimum": 1},
+                "formats": array(string(), 20),
+                "preserve": string(maxLength=4000),
+            }
+        ),
+        "interaction": {
+            "enum": ["ask_when_needed", "unattended"],
+            "default": "ask_when_needed",
+        },
+        "source_chat": obj(
+            {"chat_ref": REF, "mode": {"const": "fork"}, "checkpoint_ref": REF},
+            ["chat_ref", "mode", "checkpoint_ref"],
+        ),
+    }
+)
+TOOLS["tools_options"] = (
+    "Search a tool’s paginated parameter options after inspecting its schema.",
+    obj(
+        {
+            "tool_ref": REF,
+            "parameter": string(),
+            "query": string(maxLength=100),
+            "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
+        },
+        ["tool_ref", "parameter", "query"],
+    ),
+    False,
+)
+transform = {
+    "oneOf": [
+        obj(
+            {
+                "action": {"const": "resize"},
+                "width": {"type": "integer", "minimum": 1, "maximum": 16384},
+                "height": {"type": "integer", "minimum": 1, "maximum": 16384},
+            },
+            ["action", "width", "height"],
+        ),
+        obj(
+            {
+                "action": {"const": "crop"},
+                "box": {
+                    "type": "array",
+                    "items": {"type": "integer", "minimum": 0},
+                    "minItems": 4,
+                    "maxItems": 4,
+                },
+            },
+            ["action", "box"],
+        ),
+        obj(
+            {"action": {"const": "rotate"}, "degrees": {"enum": [90, 180, 270]}},
+            ["action", "degrees"],
+        ),
+        obj({"action": {"enum": ["flip_horizontal", "flip_vertical"]}}, ["action"]),
+    ]
+}
+content_common = {
+    "source_ref": REF,
+    "target_asset_ref": REF,
+    "expected_current_revision": REF,
+    "project_ref": REF,
+    "request_key": KEY,
+}
+content_variants = [
+    obj(
+        {
+            **content_common,
+            "format": {"const": "image"},
+            "transforms": array(transform, 20),
+        },
+        ["format", "source_ref", "transforms", "request_key"],
+    ),
+    obj(
+        {
+            **content_common,
+            "format": {"enum": ["svg", "markdown"]},
+            "text": string(maxLength=512000),
+        },
+        ["format", "text", "request_key"],
+    ),
+    obj(
+        {
+            **content_common,
+            "format": {"const": "layout"},
+            "files": array(
+                obj(
+                    {"name": string(maxLength=200), "text": string(maxLength=128000)},
+                    ["name", "text"],
+                ),
+                100,
+            ),
+        },
+        ["format", "files", "request_key"],
+    ),
+]
+TOOLS["content_update"] = (
+    "Save image transforms or a structured document. Supply target_asset_ref and expected_current_revision to revise an existing Asset; otherwise create a new Asset. Does not modify a working editor stack.",
+    {"type": "object", "oneOf": content_variants},
+    True,
+)
+
+TOOLS["assets_select"] = (
+    "Snapshot all matching Assets and exact revisions for stable bulk work. New matches arriving later are excluded.",
+    obj({"query": workspace.query_binding.schema()}, ["query"]),
+    False,
+)
+TOOLS["selections_get"] = (
+    "Read a page of a stable selection’s pinned targets. Any unlocked connection on this profile can recover it.",
+    obj(
+        {
+            "selection_ref": REF,
+            "offset": {"type": "integer", "minimum": 0, "default": 0},
+        },
+        ["selection_ref"],
+    ),
+    False,
+)
+
+TOOLS["tools_run"][1]["properties"].update(
+    {
+        "batch": array({"type": "object"}, 200),
+        "chain": array(
+            obj(
+                {
+                    "tool_ref": REF,
+                    "schema_version": string(),
+                    "parameters": {"type": "object"},
+                    "input_from_previous": string(
+                        "Media parameter receiving the previous step’s saved output."
+                    ),
+                },
+                ["tool_ref", "schema_version", "parameters"],
+            ),
+            30,
+        ),
+    }
+)
+TOOLS["jobs_retry"] = (
+    "Retry only explicitly failed items from a tool batch. Successful items are preserved; unknown dispatch outcomes are never automatically repeated.",
+    obj({"job_ref": REF, "request_key": KEY}, ["job_ref", "request_key"]),
+    True,
+)
+
+_catalog = None
+
+
+def catalog():
+    global _catalog
+    if _catalog is None:
+        result = descriptors()
+        for name, (description, schema, write) in TOOLS.items():
+            result.append(
+                Tool(
+                    name=name,
+                    description=description
+                    + (
+                        ACCESS_HELP
+                        if name not in ("access_open", "access_lock")
+                        else ""
+                    ),
+                    inputSchema=schema,
+                    annotations=ToolAnnotations(
+                        readOnlyHint=not write,
+                        destructiveHint=write,
+                        idempotentHint=name != "access_open",
+                        openWorldHint=name
+                        in ("agent_start", "agent_continue", "tools_run", "flows_run"),
+                    ),
+                )
+            )
+        for name, binding, description in [
+            (
+                "assets_query",
+                workspace.query_binding,
+                "Find and count Assets using browser filters. Use this directly for known criteria, not an agent.",
+            ),
+            (
+                "lineage_get",
+                workspace.lineage_binding,
+                "Inspect the bounded Media derivation graph before reproducing or varying a result.",
+            ),
+            (
+                "entities_search",
+                workspace.search_binding,
+                "Search named chats, Flows, boards, projects and presets.",
+            ),
+        ]:
+            result.append(
+                Tool(
+                    name=name,
+                    description=description + ACCESS_HELP,
+                    inputSchema=binding.schema(),
+                    annotations=ToolAnnotations(readOnlyHint=True),
+                )
+            )
+        _catalog = {tool.name: tool for tool in result}
+    return _catalog
+
+
+@server.list_tools()
+async def list_tools():
+    return list(catalog().values())
+
+
+async def dispatch(caller, name, arguments):
+    if name not in catalog():
+        raise McpError("unknown_tool", "Unknown tool.")
+    jsonschema.validate(arguments, catalog()[name].inputSchema)
+    if name == "access_open":
+        return await access.open(caller, arguments.get("pin"))
+    if name == "access_lock":
+        await jobs.revoke(caller.profile_id, caller.client_id)
+        return access.status(caller)
+    if name == "workspace_get":
+        from config import get_settings
+
+        profile = get_settings().get_profile(caller.profile_id)
+        return {
+            "profile_name": profile.name,
+            "profile_id": profile.id,
+            **access.status(caller),
+            "connection_boundary": "configured client credential + profile",
+            "transfer": "authenticated HTTP; packaged bridge handles local files",
+        }
+    access.require(caller, activity=name != "jobs_get")
+    db = get_database_registry().get_database(caller.profile_id)
+    args = dict(arguments)
+    with ProfileScope(caller.profile_id):
+        if name in ("agent_start", "tools_run", "flows_run", "content_update"):
+            return await jobs.accept(caller, name, args.pop("request_key"), args)
+        if name == "jobs_get":
+            return await jobs.get(caller, args["job_ref"], args.get("after", 0))
+        if name == "jobs_retry":
+            return await jobs.retry(caller, args["job_ref"], args["request_key"])
+        if name == "jobs_cancel":
+            return await jobs.cancel(caller, args["job_ref"])
+        if name in ("agent_continue", "interaction_respond"):
+            response = args.get("response")
+            if response is not None:
+                response = {**response, "scope": "once"}
+            return await jobs.control(
+                caller,
+                args["job_ref"],
+                args["controller_version"],
+                args["request_key"],
+                message=args.get("message"),
+                interaction_ref=args.get("interaction_ref"),
+                response=response,
+            )
+        if name in FAMILIES:
+            _, variants = FAMILIES[name]
+            binding = variants[args.pop("action")]
+            key = args.pop("request_key", None)
+            if binding.write and name in (
+                "custom_tools_update",
+                "flows_update",
+                "assets_delete_permanently",
+                "share_publish",
+                "containers_create",
+            ):
+                return await jobs.accept(
+                    caller, f"bound:{name}:{arguments['action']}", key, args
+                )
+            if binding.write:
+                return await jobs.mutate(
+                    caller,
+                    name + ":" + binding.function,
+                    key,
+                    args,
+                    lambda session: binding.run(caller, args, session),
+                )
+            async with db.async_session_maker() as session:
+                value = await binding.run(caller, args, session)
+                if name == "flows_get" and binding.function == "get_flow_program":
+                    import hashlib
+
+                    value["program_version"] = hashlib.sha256(
+                        value["code"].encode()
+                    ).hexdigest()
+                return value
+        async with db.async_session_maker() as session:
+            if name == "assets_select":
+                from .selections import create
+
+                return await create(caller, args["query"], session)
+            if name == "selections_get":
+                from .selections import read
+
+                return await read(
+                    caller, args["selection_ref"], args.get("offset", 0), session
+                )
+            if name == "chat_history":
+                return await workspace.chat_history(
+                    caller, args["chat_ref"], args.get("after", 0), session
+                )
+            if name == "assets_get":
+                return await workspace.assets_get(caller, args["refs"], session)
+            if name == "catalog_get":
+                return await workspace.catalog(
+                    caller, args["kind"], args.get("offset", 0), session
+                )
+            if name == "tools_search":
+                return await workspace.tools_search(
+                    caller,
+                    args.get("query", ""),
+                    args.get("task_type"),
+                    args.get("offset", 0),
+                    session,
+                )
+            if name == "tools_options":
+                tool_id, _, _ = await workspace.tool_descriptor(
+                    caller, args["tool_ref"]
+                )
+                from routes.tools import search_tool_options, SearchToolOptionsRequest
+
+                return await search_tool_options(
+                    SearchToolOptionsRequest(
+                        full_tool_id=tool_id,
+                        parameter=args["parameter"],
+                        query=args["query"],
+                        limit=args.get("limit", 50),
+                    )
+                )
+            if name == "tools_inspect":
+                return await workspace.tools_inspect(caller, args["tool_ref"])
+            if name in ("assets_query", "entities_search", "lineage_get"):
+                binding = {
+                    "assets_query": workspace.query_binding,
+                    "entities_search": workspace.search_binding,
+                    "lineage_get": workspace.lineage_binding,
+                }[name]
+                return await binding.run(caller, args, session)
+            if name == "media_read":
+                return await workspace.preview(caller, args["ref"], session)
+            if name == "media_export":
+                from .transfers import offer
+
+                return await offer(caller, args["ref"], session)
+            if name == "ui_context_get":
+                from .ui_context import read
+
+                return read(caller)
+            if name == "ui_open":
+                kind = args["ref"].split(":", 1)[0]
+                routes = {
+                    "asset": "edit-image",
+                    "board": "boards",
+                    "project": "projects",
+                    "chat": "chat",
+                    "flow": "flows",
+                }
+                if kind not in routes:
+                    raise McpError(
+                        "unsupported_handoff", "This entity has no standalone UI route."
+                    )
+                identifier = access.resolve(caller, args["ref"], kind)
+                return {
+                    "path": f"/{routes[kind]}/{identifier}",
+                    "profile_id": caller.profile_id,
+                    "delivery": "link_only",
+                }
+    raise McpError("unknown_tool", "Unknown tool.")
+
+
+@server.call_tool(validate_input=False)
+async def call_tool(name, arguments):
+    try:
+        caller = server.request_context.request.scope["mcp_caller"]
+        value = await dispatch(caller, name, arguments or {})
+        if isinstance(value, list) and value and isinstance(value[0], (TextContent,)):
+            return CallToolResult(content=value)
+        from mcp.types import ImageContent
+
+        if isinstance(value, list) and value and isinstance(value[0], ImageContent):
+            return CallToolResult(content=value)
+        payload = value if isinstance(value, dict) else {"items": value}
+        return CallToolResult(
+            content=[TextContent(type="text", text=json.dumps(payload))],
+            structuredContent=payload,
+        )
+    except McpError as exc:
+        result = {"code": exc.code, "message": exc.message}
+    except (jsonschema.ValidationError, ValueError):
+        # ValidationError repr contains rejected input, including PINs. Never log it.
+        result = {
+            "code": "invalid_arguments",
+            "message": "Arguments do not match the advertised schema.",
+        }
+    except Exception:
+        result = {
+            "code": "operation_failed",
+            "message": "The operation failed. Inspect the workspace and retry only when safe.",
+        }
+    return CallToolResult(
+        isError=True,
+        content=[TextContent(type="text", text=json.dumps(result))],
+        structuredContent=result,
+    )
+
+
+class Gateway:
+    async def __call__(self, scope, receive, send):
+        request = Request(scope, receive)
+        parts = request.url.path.split("/")
+        try:
+            if parts[:3] != ["", "mcp", "profiles"]:
+                raise ValueError()
+            index = 2
+            profile_id = parts[index + 1]
+            suffix = parts[index + 2 :]
+            origin = request.headers.get("origin")
+            if origin and origin != f"{request.url.scheme}://{request.url.netloc}":
+                raise McpError("forbidden_origin", "Origin is not allowed.")
+            if (
+                request.headers.get("x-profile-id")
+                or request.query_params.get("profile")
+                or request.headers.get("x-profile-pin")
+                or request.query_params.get("pin")
+            ):
+                raise McpError(
+                    "conflicting_profile",
+                    "Use only the profile bound in the MCP endpoint.",
+                )
+            bearer = request.headers.get("authorization", "")
+            if not bearer.startswith("Bearer ") or len(bearer) > 256:
+                raise McpError(
+                    "unauthorized", "Configure this assistant connection in Stimma."
+                )
+            caller = await access.authenticate(profile_id, bearer[7:])
+            scope["mcp_caller"] = caller
+            if suffix and suffix != [""]:
+                from .transfers import handle
+
+                with ProfileScope(profile_id):
+                    response = await handle(caller, suffix, request)
+                    await response(scope, receive, send)
+                return
+            await manager.handle_request(scope, receive, send)
+        except (IndexError, ValueError):
+            await JSONResponse({"error": "not_found"}, status_code=404)(
+                scope, receive, send
+            )
+        except McpError as exc:
+            status = (
+                401
+                if exc.code == "unauthorized"
+                else 404
+                if exc.code == "profile_disabled"
+                else 403
+            )
+            await JSONResponse(
+                {"error": exc.code, "message": exc.message}, status_code=status
+            )(scope, receive, send)
+
+
+@asynccontextmanager
+async def lifespan():
+    import asyncio
+
+    async with manager.run():
+        watcher = asyncio.create_task(jobs.watch_revocations())
+        try:
+            yield
+        finally:
+            watcher.cancel()
+            await asyncio.gather(watcher, return_exceptions=True)
+    tasks = list(jobs._tasks.values())
+    for task in tasks:
+        task.cancel()
+    import asyncio
+
+    await asyncio.gather(*tasks, return_exceptions=True)

--- a/backend/mcp_server/settings.py
+++ b/backend/mcp_server/settings.py
@@ -1,0 +1,143 @@
+"""Owner-facing MCP setup routes, protected by existing profile/PIN middleware."""
+
+from datetime import datetime
+import hashlib
+import secrets
+import uuid
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select
+from core.dependencies import get_db_session
+from core.profile_context import get_current_profile
+from config import get_settings
+from .access import access, installation_id
+from .models import McpClient
+from .jobs import revoke
+
+router = APIRouter(prefix="/api/mcp", tags=["mcp-settings"])
+
+
+class Enable(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    enabled: bool
+
+
+class Connect(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(default="Assistant", min_length=1, max_length=80)
+
+
+@router.get("/settings")
+async def settings(session=Depends(get_db_session)):
+    profile = get_settings().get_profile(get_current_profile())
+    clients = (
+        await session.scalars(
+            select(McpClient).where(
+                McpClient.deleted_at.is_(None),
+                McpClient.installation == installation_id(),
+            )
+        )
+    ).all()
+    return {
+        "enabled": profile.mcp_enabled,
+        "profile_id": profile.id,
+        "profile_name": profile.name,
+        "idle_timeout_minutes": profile.pin_idle_timeout_minutes,
+        "clients": [
+            {
+                "id": client.id,
+                "name": client.name,
+                "unlocked": bool(
+                    access.unlocks.get((profile.id, client.id))
+                    and __import__("time").time()
+                    - access.unlocks[profile.id, client.id].last_activity
+                    < max(1, profile.pin_idle_timeout_minutes) * 60
+                ),
+                "last_use": access.unlocks[(profile.id, client.id)].last_activity
+                if (profile.id, client.id) in access.unlocks
+                else None,
+            }
+            for client in clients
+        ],
+    }
+
+
+@router.put("/settings")
+async def enable(body: Enable):
+    from config_writer import patch_profile_section
+    from config import reload_settings
+
+    profile_id = get_current_profile()
+    patch_profile_section(profile_id, "mcp_enabled", body.enabled)
+    reload_settings()
+    if not body.enabled:
+        await revoke(profile_id)
+    return {"enabled": body.enabled}
+
+
+@router.post("/clients")
+async def connect(body: Connect, session=Depends(get_db_session)):
+    profile_id = get_current_profile()
+    profile = get_settings().get_profile(profile_id)
+    if not profile.mcp_enabled:
+        from fastapi import HTTPException
+
+        raise HTTPException(409, "Enable MCP for this profile first.")
+    credential = secrets.token_urlsafe(32)
+    client = McpClient(
+        id=uuid.uuid4().hex,
+        name=body.name,
+        credential_hash=hashlib.sha256(credential.encode()).hexdigest(),
+        installation=installation_id(),
+    )
+    session.add(client)
+    await session.commit()
+    return {
+        "id": client.id,
+        "name": client.name,
+        "connection": {
+            "version": 1,
+            "alias": f"{profile_id}-{client.id[:8]}",
+            "profile_id": profile_id,
+            "credential": credential,
+            "endpoint": f"http://127.0.0.1:{get_settings().server.port}/mcp/profiles/{profile_id}",
+        },
+    }
+
+
+@router.post("/lock")
+async def lock():
+    await revoke(get_current_profile())
+    return {"locked": True}
+
+
+@router.delete("/clients/{client_id}")
+async def disconnect(client_id: str, session=Depends(get_db_session)):
+    client = await session.get(McpClient, client_id)
+    if client:
+        client.deleted_at = datetime.utcnow()
+        await session.commit()
+        await revoke(get_current_profile(), client_id)
+    return {"disconnected": True}
+
+
+class ShareContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    asset_ids: list[int] = Field(min_length=1, max_length=200)
+
+
+@router.post("/context")
+async def share_context(body: ShareContext, session=Depends(get_db_session)):
+    from .ui_context import share
+    from .access import McpError
+    from fastapi import HTTPException
+
+    try:
+        result = await share(get_current_profile(), body.asset_ids, session)
+        return {
+            "shared": True,
+            "count": len(result["targets"]),
+            "expires_at": result["expires_at"],
+        }
+    except McpError as exc:
+        raise HTTPException(409, exc.message) from None

--- a/backend/mcp_server/transfers.py
+++ b/backend/mcp_server/transfers.py
@@ -1,0 +1,133 @@
+"""Authenticated transfers. Handles require both client identity and live unlock."""
+
+import hashlib
+import json
+import time
+import zipfile
+from pathlib import Path
+from urllib.parse import unquote
+from starlette.responses import FileResponse, JSONResponse
+from database_registry import get_database_registry
+from .access import access, McpError
+from .workspace import media_row
+
+MAX_UPLOAD = 512 * 1024 * 1024
+
+
+async def offer(caller, reference, session):
+    unlock = access.require(caller)
+    media = await media_row(caller, reference, session)
+    handle = access.ref(
+        caller,
+        "transfer",
+        json.dumps(
+            {
+                "media": media.id,
+                "grant": unlock.grant,
+                "client": caller.client_id,
+                "expires": time.time() + 900,
+            },
+            separators=(",", ":"),
+        ),
+    )
+    return {
+        "transfer_handle": handle,
+        "media_ref": access.ref(caller, "media", media.id),
+        "filename": Path(media.file_path).name
+        + (".zip" if Path(media.file_path).is_dir() else ""),
+        "expires_in_seconds": 900,
+        "delivery": "authenticated_download",
+    }
+
+
+async def handle(caller, suffix, request):
+    unlock = access.require(caller)
+    db = get_database_registry().get_database(caller.profile_id)
+    if suffix == ["upload"] and request.method == "POST":
+        filename = Path(unquote(request.headers.get("x-filename", "upload"))).name
+        from upload_service import UploadService
+
+        service = UploadService(caller.profile_id)
+        service.validate_file(filename)
+        content = bytearray()
+        async for chunk in request.stream():
+            if len(content) + len(chunk) > MAX_UPLOAD:
+                raise McpError("upload_too_large", "Upload exceeds 512 MiB.")
+            content.extend(chunk)
+        access.require(caller)
+        media, _ = await service.upload_file(bytes(content), filename)
+        async with db.async_session_maker() as session:
+            from asset_service import create_asset_from_media
+
+            asset = await create_asset_from_media(session, media_id=media.id)
+            await session.commit()
+            return JSONResponse(
+                {
+                    "asset_ref": access.ref(caller, "asset", asset.id),
+                    "media_ref": access.ref(caller, "media", media.id),
+                    "sha256": hashlib.sha256(content).hexdigest(),
+                }
+            )
+    if (
+        len(suffix) == 2
+        and suffix[0] == "download"
+        and request.method in ("GET", "HEAD")
+    ):
+        try:
+            spec = json.loads(access.resolve(caller, unquote(suffix[1]), "transfer"))
+        except (ValueError, KeyError):
+            raise McpError("not_found", "Transfer is unavailable.") from None
+        if (
+            spec["grant"] != unlock.grant
+            or spec["client"] != caller.client_id
+            or spec["expires"] < time.time()
+        ):
+            raise McpError(
+                "transfer_expired",
+                "Request a fresh export handle; media will not be regenerated.",
+            )
+        async with db.async_session_maker() as session:
+            media = await media_row(
+                caller, access.ref(caller, "media", spec["media"]), session
+            )
+            path = Path(media.file_path)
+            if not path.exists():
+                raise McpError("not_found", "The original file is unavailable.")
+            if path.is_dir():
+                from app_dirs import get_profile_dir
+
+                cache = get_profile_dir(caller.profile_id) / "mcp-exports"
+                cache.mkdir(parents=True, exist_ok=True)
+                bundle = cache / f"{media.file_hash}.zip"
+                if not bundle.exists():
+                    import os, uuid
+
+                    temporary = cache / f"{uuid.uuid4().hex}.tmp"
+                    try:
+                        with zipfile.ZipFile(
+                            temporary, "w", zipfile.ZIP_DEFLATED
+                        ) as archive:
+                            for member in sorted(path.rglob("*")):
+                                if member.is_symlink():
+                                    raise McpError(
+                                        "unsupported_bundle",
+                                        "Bundle contains a symbolic link.",
+                                    )
+                                if member.is_file():
+                                    archive.write(member, member.relative_to(path))
+                        os.replace(temporary, bundle)
+                    finally:
+                        temporary.unlink(missing_ok=True)
+                path = bundle
+            with path.open("rb") as stream:
+                digest = hashlib.file_digest(stream, "sha256").hexdigest()
+            return FileResponse(
+                path,
+                filename=path.name,
+                headers={
+                    "Cache-Control": "no-store",
+                    "X-Content-SHA256": digest,
+                    "X-Content-Type-Options": "nosniff",
+                },
+            )
+    raise McpError("not_found", "Transfer endpoint is unavailable.")

--- a/backend/mcp_server/ui_context.py
+++ b/backend/mcp_server/ui_context.py
@@ -1,0 +1,43 @@
+"""Explicit, temporary desktop selection snapshots; no ambient window reads."""
+
+import time
+from database import Asset, AssetRevision
+from .access import access, Caller, McpError
+
+_snapshots = {}
+
+
+async def share(profile_id, asset_ids, session):
+    _, db, stamp = access.stamp(profile_id)
+    caller = Caller(profile_id, "desktop", db.db_guid, stamp)
+    targets = []
+    for identifier in dict.fromkeys(asset_ids):
+        asset = await session.get(Asset, identifier)
+        if not asset or asset.deleted_at:
+            raise McpError("not_found", "A selected Asset is unavailable.")
+        revision = await session.get(AssetRevision, asset.current_revision_id)
+        targets.append(
+            {
+                "asset_ref": access.ref(caller, "asset", asset.id),
+                "revision_ref": access.ref(caller, "revision", revision.id),
+                "media_ref": access.ref(caller, "media", revision.primary_media_id),
+            }
+        )
+    result = {"shared": True, "targets": targets, "expires_at": time.time() + 600}
+    _snapshots[profile_id] = stamp, result
+    return result
+
+
+def read(caller):
+    snapshot = _snapshots.get(caller.profile_id)
+    if (
+        not snapshot
+        or snapshot[0] != caller.stamp
+        or snapshot[1]["expires_at"] < time.time()
+    ):
+        return {"shared": False, "targets": []}
+    return snapshot[1]
+
+
+def clear(profile_id):
+    _snapshots.pop(profile_id, None)

--- a/backend/mcp_server/workspace.py
+++ b/backend/mcp_server/workspace.py
@@ -119,9 +119,14 @@ async def tool_parameters(caller, descriptor, parameters, session):
     return result
 
 
-async def media_row(caller, reference, session):
+async def media_row(caller, reference, session, *, preview_only=False):
     kind = reference.split(":", 1)[0]
-    if kind == "asset":
+    ephemeral_run = None
+    if kind == "context_media" and preview_only:
+        identifier, ephemeral_run = json.loads(
+            access.resolve(caller, reference, "context_media")
+        )
+    elif kind == "asset":
         asset = await session.get(
             Asset, int(access.resolve(caller, reference, "asset"))
         )
@@ -139,7 +144,12 @@ async def media_row(caller, reference, session):
     else:
         identifier = int(access.resolve(caller, reference, "media"))
     row = await session.get(MediaItem, identifier)
-    if not row or row.deleted_at or row.deletion_pending_at or row.ephemeral_run_id:
+    if (
+        not row
+        or row.deleted_at
+        or row.deletion_pending_at
+        or row.ephemeral_run_id != ephemeral_run
+    ):
         raise McpError("not_found", "Media is unavailable.")
     return row
 
@@ -147,7 +157,7 @@ async def media_row(caller, reference, session):
 async def preview(caller, reference, session):
     from mcp.types import ImageContent, TextContent
 
-    row = await media_row(caller, reference, session)
+    row = await media_row(caller, reference, session, preview_only=True)
     path = Path(row.file_path)
     if not path.is_file():
         raise McpError(
@@ -282,6 +292,44 @@ async def catalog(caller, kind, offset, session):
     }
 
 
+async def flow_candidate(caller, value, shape, session):
+    """Expose typed media choices as read-only previews until the run ends."""
+    from flow_dsl.shapes import Scalar, ListShape, DictShape, TupleShape
+
+    if isinstance(shape, Scalar) and shape.kind == "media" and isinstance(value, int):
+        row = await session.get(MediaItem, value)
+        if row is None:
+            return {"available": False}
+        reference = (
+            access.ref(
+                caller, "context_media", json.dumps([row.id, row.ephemeral_run_id])
+            )
+            if row.ephemeral_run_id
+            else access.ref(caller, "media", row.id)
+        )
+        return {"preview_ref": reference}
+    if isinstance(shape, ListShape) and isinstance(value, list):
+        return [
+            await flow_candidate(caller, item, shape.element, session) for item in value
+        ]
+    if isinstance(shape, DictShape) and isinstance(value, dict):
+        return {
+            key: await flow_candidate(caller, item, shape.field_map.get(key), session)
+            for key, item in value.items()
+        }
+    if isinstance(shape, TupleShape) and isinstance(value, (list, tuple)):
+        return [
+            await flow_candidate(
+                caller,
+                item,
+                shape.elements[index] if index < len(shape.elements) else None,
+                session,
+            )
+            for index, item in enumerate(value)
+        ]
+    return present(caller, value)
+
+
 async def execute_flow(caller, args, session, chat):
     from database import Flow
     from flow_runtime import get_flow_program_path
@@ -307,7 +355,7 @@ async def execute_flow(caller, args, session, chat):
         _PENDING[request_id] = future
         metadata = {
             "type": "mcp_flow",
-            "prompt": eq.key,
+            "prompt": eq.definition.get("instructions") or eq.key,
             "candidates": present(caller, inputs.get("candidates", []), "media"),
             "v2_tool_args": {"_inprocess_request_id": request_id},
             "decision_type": eq.definition.get("hitl_type"),
@@ -319,6 +367,26 @@ async def execute_flow(caller, args, session, chat):
             .get_database(caller.profile_id)
             .async_session_maker() as question_session
         ):
+            from flow_dsl.shapes import ListShape
+
+            shape = getattr(
+                eq.definition.get("_dynamic", {}).get("candidates"), "shape", None
+            )
+            if isinstance(shape, ListShape):
+                shape = shape.element
+            metadata["candidates"] = [
+                await flow_candidate(caller, candidate, shape, question_session)
+                for candidate in inputs.get("candidates", [])
+            ]
+            if "asset" in inputs:
+                metadata["asset"] = await flow_candidate(
+                    caller,
+                    inputs["asset"],
+                    getattr(
+                        eq.definition.get("_dynamic", {}).get("asset"), "shape", None
+                    ),
+                    question_session,
+                )
             question_session.add(
                 ChatItem(
                     chat_id=chat.id,

--- a/backend/mcp_server/workspace.py
+++ b/backend/mcp_server/workspace.py
@@ -1,0 +1,495 @@
+"""Workspace reads and execution adapters shared by both MCP transports."""
+
+from __future__ import annotations
+import base64
+import hashlib
+import io
+import json
+from pathlib import Path
+from sqlalchemy import select
+from database import Asset, AssetRevision, MediaItem
+from .access import access, McpError
+from .operations import Binding, present
+
+query_binding = Binding("assets", "browse_assets", "asset")
+lineage_binding = Binding("media_files", "get_media_lineage_tree", "media")
+search_binding = Binding("search", "global_search", None)
+
+
+async def refresh_custom_tools():
+    from providers.registry import ProviderRegistry
+
+    registry = ProviderRegistry()
+    provider = registry.get_provider("user-tools")
+    if provider:
+        await registry.refresh_tools("user-tools", force_refresh=True)
+
+
+async def tool_descriptor(caller, ref):
+    from providers.registry import ProviderRegistry
+
+    tool_id = access.resolve(caller, ref, "tool")
+    if tool_id.startswith("user-tools:"):
+        await refresh_custom_tools()
+    value = ProviderRegistry().get_tool(tool_id)
+    if not value:
+        raise McpError(
+            "provider_unavailable",
+            "Tool is not currently available. Refresh the catalog.",
+        )
+    return tool_id, *value
+
+
+def tool_version(descriptor):
+    return hashlib.sha256(
+        json.dumps(
+            {
+                "parameters": descriptor.parameter_schema,
+                "output": descriptor.output_schema,
+                "definition": (descriptor.metadata or {}).get("definition_version"),
+            },
+            sort_keys=True,
+        ).encode()
+    ).hexdigest()
+
+
+async def tools_search(caller, query, task_type, offset, session):
+    from providers.registry import ProviderRegistry
+    from agent.v2.permissions import get_stp_permission_decision
+    from database import Chat
+
+    await refresh_custom_tools()
+    matches = []
+    for tool_id, provider, tool in ProviderRegistry().list_all_tools():
+        if query.lower() not in (tool.name + " " + (tool.description or "")).lower():
+            continue
+        if task_type and task_type not in (tool.task_types or [tool.task_type]):
+            continue
+        if await get_stp_permission_decision(tool_id, Chat(), session) == "deny":
+            continue
+        matches.append(
+            {
+                "tool_ref": access.ref(caller, "tool", tool_id),
+                "name": tool.name,
+                "description": tool.description,
+                "task_types": tool.task_types,
+                "provider": provider.provider_name,
+                "status": provider.status.value,
+            }
+        )
+    matches.sort(key=lambda item: (item["name"], item["tool_ref"]))
+    return {
+        "items": matches[offset : offset + 50],
+        "total": len(matches),
+        "next_offset": offset + 50 if len(matches) > offset + 50 else None,
+    }
+
+
+async def tools_inspect(caller, ref):
+    _, provider, tool = await tool_descriptor(caller, ref)
+    return {
+        "tool_ref": ref,
+        "name": tool.name,
+        "description": tool.description,
+        "schema_version": tool_version(tool),
+        "parameter_schema": tool.parameter_schema,
+        "output_schema": tool.output_schema,
+        "status": provider.status.value,
+        "media_inputs": "For media inputs use media:<opaque-reference> returned by Stimma, never a server path.",
+    }
+
+
+async def tool_parameters(caller, descriptor, parameters, session):
+    # Provider schemas retain their own types. Only negotiated media fields may
+    # resolve refs into server paths; arbitrary paths/URLs are never accepted.
+    import jsonschema
+
+    result = dict(parameters)
+    for name, schema in (descriptor.parameter_schema.get("properties") or {}).items():
+        if "x-accept-media" not in schema or name not in result:
+            continue
+        many = isinstance(result[name], list)
+        values = result[name] if many else [result[name]]
+        resolved = []
+        for ref in values:
+            media = await media_row(caller, ref, session)
+            resolved.append(str(media.file_path))
+        result[name] = resolved if many else resolved[0]
+    jsonschema.validate(result, descriptor.parameter_schema)
+    return result
+
+
+async def media_row(caller, reference, session):
+    kind = reference.split(":", 1)[0]
+    if kind == "asset":
+        asset = await session.get(
+            Asset, int(access.resolve(caller, reference, "asset"))
+        )
+        if not asset or asset.deleted_at:
+            raise McpError("not_found", "Asset is unavailable.")
+        revision = await session.get(AssetRevision, asset.current_revision_id)
+        identifier = revision.primary_media_id
+    elif kind == "revision":
+        revision = await session.get(
+            AssetRevision, int(access.resolve(caller, reference, "revision"))
+        )
+        if not revision:
+            raise McpError("not_found", "Revision is unavailable.")
+        identifier = revision.primary_media_id
+    else:
+        identifier = int(access.resolve(caller, reference, "media"))
+    row = await session.get(MediaItem, identifier)
+    if not row or row.deleted_at or row.deletion_pending_at or row.ephemeral_run_id:
+        raise McpError("not_found", "Media is unavailable.")
+    return row
+
+
+async def preview(caller, reference, session):
+    from mcp.types import ImageContent, TextContent
+
+    row = await media_row(caller, reference, session)
+    path = Path(row.file_path)
+    if not path.is_file():
+        raise McpError(
+            "preview_unavailable",
+            "This format requires a renderer or complete bundle export.",
+        )
+    if row.file_format.lower() in ("png", "jpg", "jpeg", "webp", "gif", "bmp"):
+        from PIL import Image, ImageOps
+
+        with Image.open(path) as source:
+            picture = ImageOps.exif_transpose(source)
+            picture.thumbnail((1024, 1024))
+            buffer = io.BytesIO()
+            picture.convert("RGB").save(buffer, format="JPEG", quality=85)
+        return [
+            ImageContent(
+                type="image",
+                data=base64.b64encode(buffer.getvalue()).decode(),
+                mimeType="image/jpeg",
+            )
+        ]
+    if row.file_format.lower() in (
+        "svg",
+        "md",
+        "txt",
+        "json",
+        "stimmaset.json",
+        "stimmagrid.json",
+    ):
+        if path.stat().st_size > 128 * 1024:
+            raise McpError(
+                "transfer_required", "Download this document through the bridge."
+            )
+        return [TextContent(type="text", text=path.read_text())]
+    raise McpError(
+        "preview_unavailable",
+        "Download this media through the bridge to inspect it locally.",
+    )
+
+
+async def assets_get(caller, references, session):
+    from routes.assets import get_asset
+
+    return {
+        "items": [
+            present(
+                caller,
+                await get_asset(int(access.resolve(caller, ref, "asset")), session),
+                "asset",
+            )
+            for ref in references
+        ]
+    }
+
+
+async def catalog(caller, kind, offset, session):
+    from database import Marker, Tag, SavedView
+    from config import get_settings
+
+    if kind == "sources":
+        profile = get_settings().get_profile(caller.profile_id)
+        return {
+            "items": [
+                {
+                    "ref": access.ref(
+                        caller,
+                        "source",
+                        hashlib.sha256(folder.path.encode()).hexdigest(),
+                    ),
+                    "name": Path(folder.path).name,
+                }
+                for folder in profile.folders
+            ][offset : offset + 100]
+        }
+    if kind == "skills":
+        from routes.settings import list_skills_endpoint
+
+        return {
+            "items": present(caller, await list_skills_endpoint())[
+                offset : offset + 100
+            ]
+        }
+    if kind == "formats":
+        return {
+            "upload": [
+                "png",
+                "jpg",
+                "jpeg",
+                "webp",
+                "gif",
+                "svg",
+                "mp4",
+                "webm",
+                "mov",
+                "avi",
+                "mkv",
+                "mp3",
+                "wav",
+                "flac",
+                "aac",
+                "m4a",
+                "ogg",
+            ],
+            "download": ["original", "bundle"],
+            "preview": [
+                "png",
+                "jpg",
+                "jpeg",
+                "webp",
+                "gif",
+                "svg",
+                "md",
+                "txt",
+                "json",
+            ],
+        }
+    model = {"markers": Marker, "tags": Tag, "saved_views": SavedView}[kind]
+    rows = list(
+        (
+            await session.scalars(
+                select(model).order_by(model.id).offset(offset).limit(100)
+            )
+        ).all()
+    )
+    return {
+        "items": present(
+            caller,
+            [row.to_dict() for row in rows],
+            {"markers": "marker", "tags": "tag", "saved_views": "view"}[kind],
+        ),
+        "next_offset": offset + 100 if len(rows) == 100 else None,
+    }
+
+
+async def execute_flow(caller, args, session, chat):
+    from database import Flow
+    from flow_runtime import get_flow_program_path
+    from flow_runtime.oneshot import run_flow_once
+    from upload_service import UploadService
+    from .jobs import check_execution
+
+    flow_id = int(access.resolve(caller, args["flow_ref"], "flow"))
+    flow = await session.get(Flow, flow_id)
+    if not flow or flow.deleted_at:
+        raise McpError("not_found", "Flow is unavailable.")
+    program = get_flow_program_path(flow_id).read_text()
+    if hashlib.sha256(program.encode()).hexdigest() != args["program_version"]:
+        raise McpError("schema_changed", "Inspect the Flow program again.")
+
+    async def ask(eq, inputs):
+        import asyncio, uuid
+        from database import ChatItem
+        from agent.v2.tool_permission_gate import _PENDING
+
+        request_id = f"mcp-flow:{caller.profile_id}:{uuid.uuid4().hex}"
+        future = asyncio.get_running_loop().create_future()
+        _PENDING[request_id] = future
+        metadata = {
+            "type": "mcp_flow",
+            "prompt": eq.key,
+            "candidates": present(caller, inputs.get("candidates", []), "media"),
+            "v2_tool_args": {"_inprocess_request_id": request_id},
+            "decision_type": eq.definition.get("hitl_type"),
+        }
+        from database_registry import get_database_registry
+
+        async with (
+            get_database_registry()
+            .get_database(caller.profile_id)
+            .async_session_maker() as question_session
+        ):
+            question_session.add(
+                ChatItem(
+                    chat_id=chat.id,
+                    item_type="hitl_request",
+                    item_metadata=json.dumps(metadata),
+                )
+            )
+            await question_session.commit()
+        try:
+            response = await future
+            check_execution()
+            if eq.definition.get("hitl_type") == "approve":
+                return bool(response.get("approved"))
+            candidates = inputs.get("candidates", [])
+            indices = response.get("choice_indices", [])
+            if not indices or any(i < 0 or i >= len(candidates) for i in indices):
+                raise McpError(
+                    "invalid_selection", "Choose one or more advertised candidates."
+                )
+            selected = [candidates[i] for i in indices]
+            return selected[0] if int(eq.definition.get("count", 1)) == 1 else selected
+        finally:
+            _PENDING.pop(request_id, None)
+
+    output = await run_flow_once(
+        flow_id=flow_id,
+        program_text=program,
+        inputs=args.get("inputs", json.loads(flow.inputs or "{}")),
+        project_id=flow.project_id,
+        hitl_resolver=ask,
+    )
+    results = []
+    for name, value in output.outputs.items():
+        for media in value.media:
+            row, _ = await UploadService(caller.profile_id).upload_file(
+                media.data, f"{name}.{media.file_format}", project_id=flow.project_id
+            )
+            results.append(
+                {"name": name, "media_ref": access.ref(caller, "media", row.id)}
+            )
+        if not value.media:
+            results.append({"name": name, "value": present(caller, value.value)})
+    return {"outputs": results}
+
+
+async def execute_tools(caller, args, session, chat, job):
+    from agent.v2.code_runtime import StimmaSDK, ToolResult
+    from agent.v2.workspace import get_workspace_dir, get_project_workspace
+    from .jobs import check_execution
+
+    sdk = StimmaSDK(
+        session=session,
+        chat_id=chat.id,
+        workspace_dir=get_workspace_dir(chat.id, chat.project_id),
+        project_workspace_dir=get_project_workspace(chat.project_id),
+        interrupt_checker=check_execution,
+        project_id=chat.project_id,
+    )
+    if args.get("batch") and args.get("chain"):
+        raise McpError("invalid_arguments", "Choose a batch or a chain.")
+    steps = [
+        {
+            "tool_ref": args["tool_ref"],
+            "schema_version": args["schema_version"],
+            "parameters": p,
+        }
+        for p in (args.get("batch") or [args["parameters"]])
+    ]
+    if args.get("chain"):
+        steps.extend(args["chain"])
+    manifest = {"items": []}
+    previous = None
+    for index, step in enumerate(steps):
+        check_execution()
+        tool_id, _, descriptor = await tool_descriptor(caller, step["tool_ref"])
+        if tool_version(descriptor) != step["schema_version"]:
+            raise McpError(
+                "schema_changed", "Inspect the changed tool before starting new work."
+            )
+        raw = dict(step["parameters"])
+        if step.get("input_from_previous"):
+            if not previous:
+                raise McpError(
+                    "missing_input", "The previous step did not produce media."
+                )
+            field = step["input_from_previous"]
+            schema = descriptor.parameter_schema.get("properties", {}).get(field, {})
+            if "x-accept-media" not in schema:
+                raise McpError(
+                    "invalid_arguments",
+                    "Previous output must bind to a declared media parameter.",
+                )
+            raw[field] = [previous] if schema.get("type") == "array" else previous
+        parameters = await tool_parameters(caller, descriptor, raw, session)
+        try:
+            output = await sdk._dispatch_tool(tool_id, _params_dict=parameters)
+            if isinstance(output, ToolResult):
+                saved = await sdk.library.save(output)
+                previous = access.ref(caller, "media", saved["media_id"])
+                output = present(caller, saved, "asset")
+            else:
+                output = present(caller, output)
+            manifest["items"].append(
+                {"index": index, "state": "succeeded", "output": output}
+            )
+        except Exception as exc:
+            from agent.v2.tool_permission_gate import ToolPermissionDenied
+
+            known = isinstance(exc, ToolPermissionDenied)
+            code = "forbidden" if known else "execution_outcome_unknown"
+            manifest["items"].append(
+                {
+                    "index": index,
+                    "state": "failed" if known else "interrupted",
+                    "error": {
+                        "code": code,
+                        "message": "Execution stopped; inspect retained results before starting more work.",
+                    },
+                }
+            )
+            job.result_json = json.dumps(manifest)
+            await session.commit()
+            if args.get("chain") or not known:
+                break
+        job.result_json = json.dumps(manifest)
+        await session.commit()
+    return manifest
+
+
+async def chat_history(caller, reference, after, session):
+    from database import Chat, ChatItem
+
+    chat_id = int(access.resolve(caller, reference, "chat"))
+    chat = await session.get(Chat, chat_id)
+    if not chat or chat.deleted_at:
+        raise McpError("not_found", "Chat is unavailable.")
+    rows = (
+        await session.scalars(
+            select(ChatItem)
+            .where(
+                ChatItem.chat_id == chat_id,
+                ChatItem.id > after,
+                ChatItem.item_type.in_(
+                    [
+                        "user_message",
+                        "assistant_message",
+                        "media_display",
+                        "hitl_request",
+                        "hitl_response",
+                        "error",
+                    ]
+                ),
+            )
+            .order_by(ChatItem.id)
+            .limit(100)
+        )
+    ).all()
+    return {
+        "items": [
+            present(
+                caller,
+                {
+                    "id": row.id,
+                    "type": row.item_type,
+                    "text": row.message_text,
+                    "media_ids": json.loads(row.media_ids or "[]"),
+                    "asset_ids": json.loads(row.asset_ids or "[]"),
+                },
+                "chat_item",
+            )
+            for row in rows
+        ],
+        "next_cursor": rows[-1].id if rows else after,
+    }

--- a/backend/providers/registry.py
+++ b/backend/providers/registry.py
@@ -42,6 +42,7 @@ class ProviderRegistry:
 
         self._providers: Dict[str, ToolProvider] = {}
         self._tools_cache: Dict[str, Tuple[ToolProvider, ToolDescriptor]] = {}
+        self._profile_tools = {}
         self._status_subscribers: List[Callable[[str, ProviderStatus], None]] = []
         # Subscribers fired whenever the set of available tools changes —
         # provider registered/unregistered, refresh_tools updated a provider's
@@ -50,6 +51,10 @@ class ProviderRegistry:
         self._tools_changed_subscribers: List[Callable[[], None]] = []
         self._lock = asyncio.Lock()
         self._initialized = True
+
+    def _visible_tools(self):
+        from core.profile_context import get_current_profile
+        return {**self._tools_cache, **self._profile_tools.get(get_current_profile(), {})}
 
     # --- Database Caching ---
 
@@ -73,7 +78,12 @@ class ProviderRegistry:
         from database import CachedProviderTool
         from sqlalchemy import select
 
-        session_makers = await self._get_db_session_makers()
+        if provider.provider_id == 'user-tools':
+            from core.profile_context import get_current_profile
+            from database_registry import get_database_registry
+            session_makers = [get_database_registry().get_database(get_current_profile()).async_session_maker]
+        else:
+            session_makers = await self._get_db_session_makers()
         if not session_makers:
             return
 
@@ -216,14 +226,14 @@ class ProviderRegistry:
             # Cache tools in memory
             await self._refresh_tools_for_provider(provider)
 
-            tool_count = len([t for t in self._tools_cache.values() if t[0] == provider])
+            tool_count = len([t for t in self._visible_tools().values() if t[0] == provider])
             logger.info(
                 f"Provider registered: {provider.provider_id} "
                 f"with {tool_count} tools"
             )
 
             # Copy tools list while holding lock to avoid "dict changed size during iteration"
-            tools = [tool for p, tool in self._tools_cache.values() if p == provider]
+            tools = [tool for p, tool in self._visible_tools().values() if p == provider]
 
         # Cache tools to database (outside lock to avoid blocking)
         try:
@@ -265,6 +275,9 @@ class ProviderRegistry:
                     if entry[0] != provider
                 }
 
+                if provider_id == 'user-tools':
+                    self._profile_tools.clear()
+
                 # Notify subscribers
                 self._notify_status_change(provider_id, ProviderStatus.DISCONNECTED)
 
@@ -286,6 +299,15 @@ class ProviderRegistry:
             force_refresh: If True, call provider.refresh_tools() to trigger
                           re-discovery (e.g., LoRAs). If False, just re-list.
         """
+        if provider.provider_id == 'user-tools':
+            from core.profile_context import get_current_profile
+            tools = await provider.refresh_tools() if force_refresh else await provider.list_tools()
+            self._profile_tools[get_current_profile()] = {
+                f'user-tools:{tool.id}': (provider, tool) for tool in tools
+            }
+            await self._cache_tools_to_db(provider, tools)
+            return
+
         # Clear existing tools for this provider
         self._tools_cache = {
             full_id: entry
@@ -446,13 +468,13 @@ class ProviderRegistry:
             Tuple of (provider, tool_descriptor) or None if not found
         """
         # Try exact match first
-        result = self._tools_cache.get(full_tool_id)
+        result = self._visible_tools().get(full_tool_id)
         if result:
             return result
 
         # Try case-insensitive match
         full_tool_id_lower = full_tool_id.lower()
-        for cached_id, cached_tool in self._tools_cache.items():
+        for cached_id, cached_tool in self._visible_tools().items():
             if cached_id.lower() == full_tool_id_lower:
                 return cached_tool
 
@@ -466,7 +488,7 @@ class ProviderRegistry:
             List of (full_tool_id, provider, tool_descriptor) tuples
         """
         # Copy items to avoid "dict changed size during iteration"
-        cache_snapshot = list(self._tools_cache.items())
+        cache_snapshot = list(self._visible_tools().items())
         return [
             (full_id, provider, tool)
             for full_id, (provider, tool) in cache_snapshot
@@ -483,7 +505,7 @@ class ProviderRegistry:
             List of (full_tool_id, provider, tool_descriptor) tuples
         """
         # Copy items to avoid "dict changed size during iteration"
-        cache_snapshot = list(self._tools_cache.items())
+        cache_snapshot = list(self._visible_tools().items())
         return [
             (full_id, provider, tool)
             for full_id, (provider, tool) in cache_snapshot
@@ -498,7 +520,7 @@ class ProviderRegistry:
             List of (full_tool_id, tool_descriptor) tuples
         """
         # Copy items to avoid "dict changed size during iteration"
-        cache_snapshot = list(self._tools_cache.items())
+        cache_snapshot = list(self._visible_tools().items())
         return [
             (full_id, tool)
             for full_id, (provider, tool) in cache_snapshot
@@ -678,7 +700,7 @@ class ProviderRegistry:
             await self._refresh_tools_for_provider(provider)
 
         # Cache updated tools to database
-        tools = [t for p, t in self._tools_cache.values() if p == provider]
+        tools = [t for p, t in self._visible_tools().values() if p == provider]
         try:
             await self._cache_tools_to_db(provider, tools)
         except Exception as e:
@@ -754,6 +776,7 @@ class ProviderRegistry:
             await self.unregister(provider_id)
 
         self._tools_cache.clear()
+        self._profile_tools.clear()
         self._status_subscribers.clear()
 
     # --- Singleton Access ---
@@ -769,4 +792,5 @@ class ProviderRegistry:
         if cls._instance:
             cls._instance._providers.clear()
             cls._instance._tools_cache.clear()
+            cls._instance._profile_tools.clear()
             cls._instance._status_subscribers.clear()

--- a/backend/providers/user_tools.py
+++ b/backend/providers/user_tools.py
@@ -89,10 +89,39 @@ class UserToolsProvider(ToolProvider):
     """Provider for flows frozen into first-class tools."""
 
     def __init__(self):
+        self._profile_state = {}
         self._status = ProviderStatus.DISCONNECTED
         self._descriptors: Dict[str, ToolDescriptor] = {}
         self._rows: Dict[str, Any] = {}  # tool_id -> UserTool.to_dict()
         self._assets: Dict[str, bytes] = {}
+
+    def _state(self):
+        from core.profile_context import get_current_profile
+        return self._profile_state.setdefault(get_current_profile(), {})
+
+    @property
+    def _descriptors(self):
+        return self._state().setdefault('descriptors', {})
+
+    @_descriptors.setter
+    def _descriptors(self, value):
+        self._state()['descriptors'] = value
+
+    @property
+    def _rows(self):
+        return self._state().setdefault('rows', {})
+
+    @_rows.setter
+    def _rows(self, value):
+        self._state()['rows'] = value
+
+    @property
+    def _assets(self):
+        return self._state().setdefault('assets', {})
+
+    @_assets.setter
+    def _assets(self, value):
+        self._state()['assets'] = value
 
     @property
     def provider_id(self) -> str:
@@ -172,16 +201,20 @@ class UserToolsProvider(ToolProvider):
                         "flow_id": row.flow_id,
                         "user_tool_id": row.id,
                         "provenance": "user-flow",
+                        "definition_version": __import__("hashlib").sha256((row.program_text + (row.hitl_policies or "") + (row.output_map or "")).encode()).hexdigest(),
                     },
                 )
                 # to_dict() omits program_text (kept out of API responses); the
                 # provider needs the runnable body to execute, so include it here.
                 rows[tool_id] = {**row.to_dict(), "program_text": row.program_text}
 
+        self._state()['loaded'] = True
         self._descriptors = descriptors
         self._rows = rows
 
     async def list_tools(self) -> List[ToolDescriptor]:
+        if 'loaded' not in self._state():
+            await self._load_tools()
         return list(self._descriptors.values())
 
     async def get_tool(self, tool_id: str) -> Optional[ToolDescriptor]:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,20 +7,21 @@ authors = [{ name = "Stimma", email = "stimmant@stimma.ai" }]
 requires-python = ">=3.11"
 dependencies = [
     # Web framework
-    "fastapi==0.104.1",
-    "uvicorn[standard]==0.24.0",
-    "python-multipart==0.0.6",
+    "fastapi>=0.115,<1",
+    "uvicorn[standard]>=0.31.1,<1",
+    "python-multipart>=0.0.9,<1",
     "sse-starlette==1.8.2",
     "websockets==12.0",
     "aiohttp==3.9.1",
+    "mcp>=1.26,<2",
     # Database
     "sqlalchemy==2.0.23",
     "aiosqlite==0.19.0",
     "greenlet>=3.0.0",  # Required for SQLAlchemy async
     "alembic",
     # Data validation & config
-    "pydantic==2.5.0",
-    "pydantic-settings==2.1.0",
+    "pydantic>=2.11,<3",
+    "pydantic-settings>=2.5.2,<3",
     "pyyaml==6.0.1",
     "ruamel.yaml>=0.18.0",
     # Image processing

--- a/backend/routes/chats.py
+++ b/backend/routes/chats.py
@@ -1636,6 +1636,12 @@ async def create_chat_item(
     if not chat:
         raise HTTPException(status_code=404, detail="Chat not found")
 
+    if request.item_type == 'user_message':
+        from mcp_server.jobs import takeover, execution_caller
+        if execution_caller.get() is None:
+            from core.profile_context import get_current_profile
+            await takeover(get_current_profile(), chat_id)
+
     # Build item_metadata, including attachments if present
     item_metadata = request.item_metadata
     if request.item_type == "user_message" and request.attachments:

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -281,6 +281,8 @@ async def set_pin(profile_id: str, request: SetPinRequest):
     # Clear PIN verification cache for this profile
     from core.middleware import clear_pin_cache
     clear_pin_cache(profile_id)
+    from mcp_server.jobs import revoke
+    await revoke(profile_id)
 
     from telemetry import get_telemetry_client
     get_telemetry_client().track(

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -900,3 +900,53 @@ def program():
         for task in list(jobs._tasks.values()):
             task.cancel()
         await asyncio.gather(*list(jobs._tasks.values()), return_exceptions=True)
+
+
+async def test_flow_candidate_preview_is_temporary_and_read_only(mcp_http):
+    from mcp_server.workspace import flow_candidate
+    from mcp_server.access import access
+    from database import MediaItem
+    from database_registry import get_database_registry
+    from flow_dsl.shapes import Scalar
+    from PIL import Image
+    import io
+
+    data = io.BytesIO()
+    Image.new("RGB", (4, 4), "green").save(data, format="PNG")
+    await rpc(mcp_http, "access_open")
+    uploaded = (
+        await mcp_http.post(
+            "/mcp/profiles/default/upload",
+            content=data.getvalue(),
+            headers={"X-Filename": "candidate.png"},
+        )
+    ).json()
+    caller = await access.authenticate("default", "test-credential-one")
+    async with (
+        get_database_registry().get_database("default").async_session_maker() as session
+    ):
+        media = await session.get(
+            MediaItem, int(access.resolve(caller, uploaded["media_ref"], "media"))
+        )
+        media.ephemeral_run_id = "test-candidate-run"
+        await session.commit()
+        try:
+            candidate = await flow_candidate(caller, media.id, Scalar("media"), session)
+            result = await rpc(
+                mcp_http, "media_read", {"ref": candidate["preview_ref"]}
+            )
+            assert (
+                not result.get("isError") and result["content"][0]["type"] == "image"
+            ), result
+            assert (
+                await rpc(mcp_http, "media_export", {"ref": candidate["preview_ref"]})
+            )["isError"]
+            # Reusing a payload for another run cannot reuse this preview authority.
+            media.ephemeral_run_id = "different-run"
+            await session.commit()
+            assert (
+                await rpc(mcp_http, "media_read", {"ref": candidate["preview_ref"]})
+            )["isError"]
+        finally:
+            media.ephemeral_run_id = None
+            await session.commit()

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -1,0 +1,902 @@
+"""MCP wire, profile boundary and durable retry integration tests."""
+
+import asyncio
+import hashlib
+import json
+import uuid
+import pytest
+import httpx
+from sqlalchemy import select, func
+
+
+@pytest.fixture(scope="module")
+async def mcp_app(test_app):
+    from mcp_server.server import Gateway, lifespan
+    from mcp_server.settings import router
+    from mcp_server.access import installation_id
+    from mcp_server.models import McpClient
+    from config import get_settings
+    from database_registry import get_database_registry
+
+    profile = get_settings().get_profile("default")
+    profile.mcp_enabled = True
+    db = get_database_registry().get_database("default")
+    async with db.async_session_maker() as session:
+        for name in ("one", "two"):
+            session.add(
+                McpClient(
+                    id=name,
+                    name=name,
+                    credential_hash=hashlib.sha256(
+                        ("test-credential-" + name).encode()
+                    ).hexdigest(),
+                    installation=installation_id(),
+                )
+            )
+        await session.commit()
+    test_app.include_router(router)
+    test_app.mount("/mcp", Gateway())
+    ready, stop = asyncio.Event(), asyncio.Event()
+
+    async def owner():
+        async with lifespan():
+            ready.set()
+            await stop.wait()
+
+    task = asyncio.create_task(owner())
+    await ready.wait()
+    yield test_app
+    stop.set()
+    await task
+
+
+@pytest.fixture
+async def mcp_http(mcp_app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=mcp_app),
+        base_url="http://test",
+        headers={
+            "Authorization": "Bearer test-credential-one",
+            "Accept": "application/json, text/event-stream",
+            "MCP-Protocol-Version": "2025-11-25",
+        },
+    ) as client:
+        yield client
+
+
+async def rpc(client, name, args=None):
+    response = await client.post(
+        "/mcp/profiles/default",
+        json={
+            "jsonrpc": "2.0",
+            "id": uuid.uuid4().hex,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": args or {}},
+        },
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert "result" in data, data
+    return data["result"]
+
+
+def body(result):
+    return result.get("structuredContent") or json.loads(result["content"][0]["text"])
+
+
+async def test_discovery_locked_and_actual_sdk_client(mcp_http, mcp_app):
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamable_http_client
+
+    async with streamable_http_client(
+        "http://test/mcp/profiles/default", http_client=mcp_http
+    ) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            assert {"agent_start", "tools_run", "boards_update", "media_export"} <= {
+                t.name for t in tools.tools
+            }
+            result = await session.call_tool("workspace_get", {})
+            assert result.structuredContent["profile_id"] == "default"
+
+
+async def test_credentials_origin_profile_headers(mcp_http):
+    request = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+    for headers in (
+        {"Authorization": "Bearer wrong"},
+        {"Origin": "https://attacker.example"},
+        {"X-Profile-ID": "another"},
+    ):
+        response = await mcp_http.post(
+            "/mcp/profiles/default", json=request, headers=headers
+        )
+        assert response.status_code in (401, 403)
+    response = await mcp_http.post("/mcp/profiles/another", json=request)
+    assert response.status_code == 404
+
+
+async def test_unlock_is_per_credential_and_survives_reconnect(mcp_http, mcp_app):
+    await rpc(mcp_http, "access_lock")
+    locked = await rpc(mcp_http, "assets_query")
+    assert locked["isError"] and body(locked)["code"] == "profile_locked"
+    assert body(await rpc(mcp_http, "access_open"))["locked"] is False
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=mcp_app),
+        base_url="http://test",
+        headers=dict(mcp_http.headers),
+    ) as other:
+        assert body(await rpc(other, "workspace_get"))["locked"] is False
+        other.headers["Authorization"] = "Bearer test-credential-two"
+        assert body(await rpc(other, "workspace_get"))["locked"] is True
+
+
+async def test_synchronous_create_receipt_is_atomic_and_retryable(mcp_http):
+    await rpc(mcp_http, "access_open")
+    args = {
+        "action": "create",
+        "request": {"name": "MCP retry board"},
+        "request_key": "board-retry",
+    }
+    first = await rpc(mcp_http, "boards_update", args)
+    assert not first.get("isError"), first
+    second = await rpc(mcp_http, "boards_update", args)
+    assert body(first) == body(second)
+    conflict = await rpc(
+        mcp_http, "boards_update", {**args, "request": {"name": "Changed"}}
+    )
+    assert body(conflict)["code"] == "request_key_conflict"
+    result = await rpc(
+        mcp_http, "boards_get", {"action": "detail", "board_id": body(first)["id"]}
+    )
+    assert not result.get("isError"), result
+    assert body(result)["name"] == "MCP retry board"
+
+
+async def test_query_and_catalog_schema(mcp_http):
+    await rpc(mcp_http, "access_open")
+    for name, args in [
+        ("assets_query", {}),
+        ("catalog_get", {"kind": "markers"}),
+        ("projects_get", {"action": "list"}),
+        ("entities_search", {"q": "MCP"}),
+    ]:
+        result = await rpc(mcp_http, name, args)
+        assert not result.get("isError"), (name, result)
+    result = await rpc(
+        mcp_http,
+        "projects_update",
+        {
+            "action": "update",
+            "project_id": "1",
+            "request": {"agent_tool_config": {"allowed_tools": ["*"]}},
+            "request_key": "bad",
+        },
+    )
+    assert result["isError"]
+
+
+async def test_unknown_fields_and_pin_not_echoed(mcp_http):
+    secret = "do-not-log-this-pin"
+    result = await rpc(mcp_http, "access_open", {"pin": secret, "unexpected": True})
+    assert result["isError"]
+    assert secret not in json.dumps(result)
+
+
+async def test_pin_expiry_and_revocation(mcp_http, monkeypatch):
+    from mcp_server.access import access
+    from config import get_settings
+    import bcrypt
+
+    profile = get_settings().get_profile("default")
+    monkeypatch.setattr(
+        profile, "pin_hash", bcrypt.hashpw(b"1234", bcrypt.gensalt(rounds=4)).decode()
+    )
+    assert body(await rpc(mcp_http, "workspace_get"))["locked"]
+    result = await rpc(mcp_http, "access_open", {"pin": "1234"})
+    assert not body(result)["locked"]
+    unlock = access.unlocks["default", "one"]
+    unlock.last_activity -= 3600
+    assert body(await rpc(mcp_http, "workspace_get"))["locked"]
+    monkeypatch.setattr(profile, "pin_hash", None)
+
+
+async def test_job_lost_start_response_does_not_run_twice(mcp_http, monkeypatch):
+    from mcp_server import jobs
+
+    spawned = []
+    monkeypatch.setattr(jobs, "spawn", lambda *args, **kwargs: spawned.append(args))
+    await rpc(mcp_http, "access_open")
+    args = {"brief": "Make a cover", "request_key": "agent-retry"}
+    first = await rpc(mcp_http, "agent_start", args)
+    assert not first.get("isError"), first
+    second = await rpc(mcp_http, "agent_start", args)
+    assert body(first) == body(second)
+    assert len(spawned) == 1
+    recovered = await rpc(mcp_http, "jobs_get", {"job_ref": body(first)["job_ref"]})
+    assert body(recovered)["state"] == "interrupted"
+
+
+async def test_reference_cannot_cross_profile(mcp_http):
+    from dataclasses import replace
+    from mcp_server.access import access, McpError
+
+    caller = await access.authenticate("default", "test-credential-one")
+    reference = access.ref(caller, "asset", 1)
+    with pytest.raises(McpError):
+        access.resolve(replace(caller, profile_id="other"), reference, "asset")
+
+
+async def test_agent_runtime_ids_are_profile_scoped(mcp_app):
+    from agent.v2 import service
+    from core.profile_context import ProfileScope
+
+    with ProfileScope("default"):
+        service._active_chat_executions.add(service._chat_key(42))
+        service._mark_interrupted(42)
+        assert service.is_execution_active(42)
+    with ProfileScope("another"):
+        assert not service.is_execution_active(42)
+        assert not service._is_interrupted(42)
+        assert service.get_active_chat_ids() == []
+    with ProfileScope("default"):
+        service._active_chat_executions.discard(service._chat_key(42))
+        service._clear_interrupt(42)
+
+
+async def test_upload_preview_download_range_and_relock(mcp_http):
+    import io
+    from PIL import Image
+    from urllib.parse import quote
+
+    image = Image.new("RGB", (12, 12), "red")
+    data = io.BytesIO()
+    image.save(data, format="PNG")
+    await rpc(mcp_http, "access_open")
+    response = await mcp_http.post(
+        "/mcp/profiles/default/upload",
+        content=data.getvalue(),
+        headers={
+            "X-Filename": "sample.png",
+            "Content-Type": "application/octet-stream",
+        },
+    )
+    assert response.status_code == 200, response.text
+    refs = response.json()
+    preview = await rpc(mcp_http, "media_read", {"ref": refs["media_ref"]})
+    assert not preview.get("isError"), preview
+    assert preview["content"][0]["type"] == "image"
+    export = body(await rpc(mcp_http, "media_export", {"ref": refs["media_ref"]}))
+    url = "/mcp/profiles/default/download/" + quote(export["transfer_handle"], safe="")
+    downloaded = await mcp_http.get(url)
+    assert downloaded.status_code == 200, downloaded.text
+    assert downloaded.content == data.getvalue()
+    partial = await mcp_http.get(url, headers={"Range": "bytes=0-9"})
+    assert partial.status_code == 206
+    assert partial.content == data.getvalue()[:10]
+    assets = body(await rpc(mcp_http, "assets_get", {"refs": [refs["asset_ref"]]}))
+    assert assets["items"][0]["revision"]["id"].startswith("revision:")
+    assert "file_path" not in json.dumps(assets)
+    await rpc(mcp_http, "access_lock")
+    assert (await mcp_http.get(url)).status_code == 403
+    await rpc(mcp_http, "access_open")
+    assert (await mcp_http.get(url)).status_code == 403
+
+
+async def test_marker_assignment_accepts_refs(mcp_http):
+    await rpc(mcp_http, "access_open")
+    assets = body(await rpc(mcp_http, "assets_query"))
+    assert assets["items"]
+    asset = assets["items"][0]
+    markers = body(await rpc(mcp_http, "catalog_get", {"kind": "markers"}))
+    marker = markers["items"][0]
+    from mcp_server.server import catalog
+
+    schema = catalog()["markers_update"].inputSchema
+    # The same schema used by the host names every action-specific field.
+    result = await rpc(
+        mcp_http,
+        "markers_update",
+        {
+            "action": "assign",
+            "request": {
+                "asset_ids": [
+                    asset["asset_id"] if "asset_id" in asset else asset["id"]
+                ],
+                "marker_id": marker["id"],
+                "add": True,
+            },
+            "request_key": "marker-add",
+        },
+    )
+    assert not result.get("isError"), (result, schema)
+
+
+async def test_sdk_debug_logs_never_record_pin(mcp_http, caplog):
+    import logging
+
+    caplog.set_level(logging.DEBUG, logger="mcp.server.lowlevel.server")
+    await rpc(mcp_http, "access_open", {"pin": "unique-sensitive-pin"})
+    assert "unique-sensitive-pin" not in caplog.text
+
+
+async def test_delegation_finishes_after_idle_expiry_and_reuses_chat(
+    mcp_http, monkeypatch
+):
+    from mcp_server import jobs
+    from mcp_server.access import access
+    from database import ChatItem
+    import agent
+
+    calls = []
+
+    async def fake_run(**kwargs):
+        calls.append(kwargs["chat"].id)
+        access.unlocks["default", "one"].last_activity -= 3600
+        jobs.check_execution()
+        kwargs["session"].add(
+            ChatItem(
+                chat_id=kwargs["chat"].id,
+                item_type="assistant_message",
+                message_text="Done",
+            )
+        )
+        await kwargs["session"].commit()
+
+    monkeypatch.setattr(agent, "run_agent", fake_run)
+    await rpc(mcp_http, "access_open")
+    accepted = body(
+        await rpc(
+            mcp_http,
+            "agent_start",
+            {"brief": "Test creative brief", "request_key": "finish-after-expiry"},
+        )
+    )
+    task = jobs._tasks.get(
+        (
+            "default",
+            access.resolve(
+                await access.authenticate("default", "test-credential-one"),
+                accepted["job_ref"],
+                "job",
+            ),
+        )
+    )
+    if task:
+        await task
+    await rpc(mcp_http, "access_open")
+    result = body(await rpc(mcp_http, "jobs_get", {"job_ref": accepted["job_ref"]}))
+    assert result["state"] == "succeeded", result
+    continued = body(
+        await rpc(
+            mcp_http,
+            "agent_continue",
+            {
+                "job_ref": accepted["job_ref"],
+                "controller_version": result["controller_version"],
+                "message": "Refine it",
+                "request_key": "follow-up",
+            },
+        )
+    )
+    await asyncio.gather(*list(jobs._tasks.values()))
+    assert len(calls) == 2 and calls[0] == calls[1]
+    assert continued["chat_ref"] == accepted["chat_ref"]
+
+
+async def test_desktop_takeover_rejects_stale_continuation(mcp_http, monkeypatch):
+    from mcp_server import jobs
+    from mcp_server.access import access
+
+    monkeypatch.setattr(jobs, "spawn", lambda *a, **k: None)
+    await rpc(mcp_http, "access_open")
+    job = body(
+        await rpc(
+            mcp_http, "agent_start", {"brief": "Handoff", "request_key": "handoff"}
+        )
+    )
+    caller = await access.authenticate("default", "test-credential-one")
+    chat_id = int(access.resolve(caller, job["chat_ref"], "chat"))
+    await jobs.takeover("default", chat_id)
+    result = await rpc(
+        mcp_http,
+        "agent_continue",
+        {
+            "job_ref": job["job_ref"],
+            "controller_version": 1,
+            "message": "Stale reply",
+            "request_key": "stale-reply",
+        },
+    )
+    assert body(result)["code"] == "control_changed"
+
+
+async def wait_job(client, accepted):
+    from mcp_server import jobs
+
+    await asyncio.gather(*list(jobs._tasks.values()))
+    return body(await rpc(client, "jobs_get", {"job_ref": accepted["job_ref"]}))
+
+
+async def test_saved_edit_and_selection_pins_revision(mcp_http):
+    await rpc(mcp_http, "access_open")
+    accepted = body(
+        await rpc(
+            mcp_http,
+            "content_update",
+            {"format": "markdown", "text": "# Original", "request_key": "new-document"},
+        )
+    )
+    first = await wait_job(mcp_http, accepted)
+    assert first["state"] == "succeeded", first
+    refs = first["result"]
+    selected = body(await rpc(mcp_http, "assets_select", {"query": {}}))
+    before = body(
+        await rpc(
+            mcp_http, "selections_get", {"selection_ref": selected["selection_ref"]}
+        )
+    )
+    args = {
+        "format": "markdown",
+        "text": "# Revised",
+        "target_asset_ref": refs["asset_ref"],
+        "expected_current_revision": refs["revision_ref"],
+        "request_key": "revise-document",
+    }
+    revised = await wait_job(
+        mcp_http, body(await rpc(mcp_http, "content_update", args))
+    )
+    assert revised["state"] == "succeeded", revised
+    assert revised["result"]["revision_ref"] != refs["revision_ref"]
+    after = body(
+        await rpc(
+            mcp_http, "selections_get", {"selection_ref": selected["selection_ref"]}
+        )
+    )
+    assert before == after
+    args.update(text="# Stale", request_key="stale-revision")
+    conflict = await wait_job(
+        mcp_http, body(await rpc(mcp_http, "content_update", args))
+    )
+    assert (
+        conflict["state"] == "failed"
+        and conflict["result"]["code"] == "revision_conflict"
+    ), conflict
+
+
+async def test_unknown_provider_outcome_is_retained_and_not_retried(
+    mcp_http, monkeypatch
+):
+    from types import SimpleNamespace
+    from mcp_server import workspace
+    from mcp_server.access import access
+    from agent.v2.code_runtime import StimmaSDK
+
+    descriptor = SimpleNamespace(
+        parameter_schema={
+            "type": "object",
+            "properties": {"prompt": {"type": "string"}},
+        },
+        output_schema={},
+        metadata={},
+    )
+
+    async def descriptor_for(*args):
+        return "test:fake", None, descriptor
+
+    monkeypatch.setattr(workspace, "tool_descriptor", descriptor_for)
+    calls = []
+
+    async def dispatch(self, *args, **kwargs):
+        calls.append(kwargs["_params_dict"]["prompt"])
+        if len(calls) == 2:
+            raise TimeoutError("provider may have finished")
+        return {"text": "confirmed result"}
+
+    monkeypatch.setattr(StimmaSDK, "_dispatch_tool", dispatch)
+    await rpc(mcp_http, "access_open")
+    caller = await access.authenticate("default", "test-credential-one")
+    accepted = body(
+        await rpc(
+            mcp_http,
+            "tools_run",
+            {
+                "tool_ref": access.ref(caller, "tool", "test:fake"),
+                "schema_version": workspace.tool_version(descriptor),
+                "parameters": {},
+                "batch": [
+                    {"prompt": "first"},
+                    {"prompt": "second"},
+                    {"prompt": "third"},
+                ],
+                "request_key": "unknown-batch",
+            },
+        )
+    )
+    result = await wait_job(mcp_http, accepted)
+    assert result["state"] == "failed", result
+    assert [i["state"] for i in result["result"]["items"]] == [
+        "succeeded",
+        "interrupted",
+    ]
+    retry = await rpc(
+        mcp_http,
+        "jobs_retry",
+        {"job_ref": accepted["job_ref"], "request_key": "retry-unknown"},
+    )
+    assert body(retry)["code"] == "retry_unavailable"
+    assert calls == ["first", "second"]
+
+
+async def test_stdio_bridge_roundtrip_and_private_install(
+    mcp_app, tmp_path, monkeypatch, capsys
+):
+    import os, socket, sys
+    import uvicorn
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+    from mcp_server.bridge import install, config_path
+    from mcp_server.access import installation_id
+    from mcp_server.models import McpClient
+    from database_registry import get_database_registry
+
+    credential = "test-only-bridge-credential-with-sufficient-length"
+    async with (
+        get_database_registry().get_database("default").async_session_maker() as session
+    ):
+        session.add(
+            McpClient(
+                id="bridge-test",
+                name="Bridge test",
+                credential_hash=hashlib.sha256(credential.encode()).hexdigest(),
+                installation=installation_id(),
+            )
+        )
+        await session.commit()
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    port = listener.getsockname()[1]
+    config = {
+        "alias": "test",
+        "credential": credential,
+        "endpoint": f"http://127.0.0.1:{port}/mcp/profiles/default",
+        "download_directory": str(tmp_path / "downloads"),
+    }
+    bootstrap = tmp_path / "connection.json"
+    bootstrap.write_text(json.dumps(config))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    install(bootstrap)
+    assert config_path("test").stat().st_mode & 0o777 == 0o600
+    assert credential not in capsys.readouterr().out
+    server = uvicorn.Server(
+        uvicorn.Config(mcp_app, lifespan="off", access_log=False, log_level="error")
+    )
+    task = asyncio.create_task(server.serve(sockets=[listener]))
+    while not server.started:
+        await asyncio.sleep(0.01)
+    try:
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "mcp_server.bridge", "bridge", "test"],
+            env=dict(os.environ),
+        )
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as client:
+                await client.initialize()
+                names = {t.name for t in (await client.list_tools()).tools}
+                assert {"media_upload", "media_download", "agent_start"} <= names
+                opened = await client.call_tool("access_open", {})
+                assert not opened.isError
+                from PIL import Image
+
+                source = tmp_path / "bridge.png"
+                Image.new("RGB", (4, 4), "blue").save(source)
+                uploaded = await client.call_tool("media_upload", {"path": str(source)})
+                assert not uploaded.isError, uploaded
+                downloaded = await client.call_tool(
+                    "media_download", {"ref": uploaded.structuredContent["media_ref"]}
+                )
+                assert not downloaded.isError, downloaded
+                from pathlib import Path
+
+                assert (
+                    Path(downloaded.structuredContent["path"]).read_bytes()
+                    == source.read_bytes()
+                )
+    finally:
+        server.should_exit = True
+        await task
+        listener.close()
+
+
+async def test_ui_selection_requires_explicit_share_and_lock_clears_it(mcp_http):
+    from mcp_server.access import access
+
+    await rpc(mcp_http, "access_open")
+    assert not body(await rpc(mcp_http, "ui_context_get"))["shared"]
+    item = body(await rpc(mcp_http, "assets_query"))["items"][0]
+    reference = item.get("asset_id") or item["id"]
+    caller = await access.authenticate("default", "test-credential-one")
+    identifier = int(access.resolve(caller, reference, "asset"))
+    response = await mcp_http.post(
+        "/api/mcp/context",
+        json={"asset_ids": [identifier]},
+        headers={"X-Profile-ID": "default"},
+    )
+    assert response.status_code == 200, response.text
+    shared = body(await rpc(mcp_http, "ui_context_get"))
+    assert shared["shared"] and shared["targets"][0]["asset_ref"] == reference
+    await mcp_http.post("/api/mcp/lock", headers={"X-Profile-ID": "default"})
+    await rpc(mcp_http, "access_open")
+    assert not body(await rpc(mcp_http, "ui_context_get"))["shared"]
+
+
+async def test_flow_runs_real_scalar_program(mcp_http, monkeypatch):
+    from mcp_server import workspace
+
+    original = workspace.execute_flow
+    errors = []
+
+    async def capture(*args):
+        try:
+            return await original(*args)
+        except Exception as exc:
+            errors.append(repr(exc))
+            raise
+
+    monkeypatch.setattr(workspace, "execute_flow", capture)
+    from core.profile_context import ProfileScope
+    from database import Flow
+    from database_registry import get_database_registry
+    from flow_runtime import create_flow_directory, get_flow_program_path
+    from mcp_server.access import access
+
+    program = """from stimma.flow import flow, output, code, phase
+@flow(name="MCP scalar", outputs={"result": output("str")})
+def program():
+    with phase("Greeting"):
+        return code(lambda: "Hello from Flow", inputs={}, output_type="text")
+"""
+    caller = await access.authenticate("default", "test-credential-one")
+    with ProfileScope("default"):
+        async with (
+            get_database_registry()
+            .get_database("default")
+            .async_session_maker() as session
+        ):
+            flow = Flow(name="MCP scalar")
+            session.add(flow)
+            await session.flush()
+            create_flow_directory(flow.id)
+            get_flow_program_path(flow.id).write_text(program)
+            await session.commit()
+            ref = access.ref(caller, "flow", flow.id)
+    await rpc(mcp_http, "access_open")
+    started = body(
+        await rpc(
+            mcp_http,
+            "flows_run",
+            {
+                "flow_ref": ref,
+                "program_version": hashlib.sha256(program.encode()).hexdigest(),
+                "request_key": "scalar-flow",
+            },
+        )
+    )
+    result = await wait_job(mcp_http, started)
+    assert result["state"] == "succeeded", (result, errors)
+    assert not errors, errors
+    assert result["result"]["outputs"] == [
+        {"name": "result", "value": "Hello from Flow"}
+    ]
+
+
+async def test_second_profile_database_and_custom_tool_cache_are_isolated(
+    mcp_http, tmp_path, monkeypatch
+):
+    from config import get_settings, ProfileConfig
+    from core.profile_context import ProfileScope
+    from database import Board
+    from database_registry import get_database_registry
+    from mcp_server.access import access, installation_id
+    from mcp_server.models import McpClient
+    from providers.user_tools import UserToolsProvider
+    from providers.registry import ProviderRegistry
+
+    settings = get_settings()
+    other = ProfileConfig(
+        id="mcp-other",
+        name="Other",
+        database=str(tmp_path / "other.db"),
+        mcp_enabled=True,
+    )
+    monkeypatch.setattr(settings, "profiles", [*settings.profiles, other])
+    registry = get_database_registry()
+    registry.register_profile(other)
+    try:
+        with ProfileScope(other.id):
+            from utils.migrations import run_all_migrations
+
+            run_all_migrations()
+            await registry.init_database(other.id)
+            async with registry.get_database(other.id).async_session_maker() as session:
+                session.add(
+                    McpClient(
+                        id="one",
+                        name="Other connection",
+                        credential_hash=hashlib.sha256(
+                            b"other-profile-credential"
+                        ).hexdigest(),
+                        installation=installation_id(),
+                    )
+                )
+                session.add(Board(id=1, name="Other profile board"))
+                await session.commit()
+        unauthorized = await mcp_http.post(
+            "/mcp/profiles/mcp-other",
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+        assert unauthorized.status_code == 401
+        caller = await access.authenticate("default", "test-credential-one")
+        other_caller = await access.authenticate(other.id, "other-profile-credential")
+        from mcp_server.access import McpError
+
+        with pytest.raises(McpError):
+            access.resolve(other_caller, access.ref(caller, "board", 1), "board")
+        provider = UserToolsProvider()
+        catalog = ProviderRegistry()
+        from types import SimpleNamespace
+
+        descriptor = SimpleNamespace(id="same-id", name="Private tool")
+
+        async def no_cache(*args):
+            pass
+
+        monkeypatch.setattr(catalog, "_cache_tools_to_db", no_cache)
+        with ProfileScope("default"):
+            provider._state()["loaded"] = True
+            provider._descriptors = {"same-id": descriptor}
+            await catalog._refresh_tools_for_provider(provider)
+            assert catalog.get_tool("user-tools:same-id")[1] is descriptor
+        with ProfileScope(other.id):
+            assert await provider.list_tools() == []
+            await catalog._refresh_tools_for_provider(provider)
+            assert catalog.get_tool("user-tools:same-id") is None
+        with ProfileScope("default"):
+            assert catalog.get_tool("user-tools:same-id")[1] is descriptor
+        catalog._profile_tools.pop("default", None)
+        catalog._profile_tools.pop(other.id, None)
+    finally:
+        await registry.unregister_profile(other.id)
+
+
+async def test_atomic_mutation_broadcasts_only_after_commit(mcp_http):
+    from mcp_server.access import access
+    from mcp_server.jobs import mutate
+    from utils.websocket import WebSocketManager
+    from database import Board
+    from database_registry import get_database_registry
+    from core.profile_context import ProfileScope
+
+    caller = await access.authenticate("default", "test-credential-one")
+    db = get_database_registry().get_database("default")
+    manager = WebSocketManager()
+    delivered = []
+
+    class Receiver:
+        async def send_text(self, message):
+            async with db.async_session_maker() as session:
+                delivered.append(
+                    await session.scalar(
+                        select(Board.name).where(
+                            Board.id == json.loads(message)["data"]["board_id"]
+                        )
+                    )
+                )
+
+    manager.active_connections.append(Receiver())
+
+    async def change(session):
+        board = Board(name="Committed before broadcast")
+        session.add(board)
+        await session.commit()
+        await manager.broadcast("board_created", {"board_id": board.id})
+        assert delivered == []
+        return {"created": True}
+
+    with ProfileScope("default"):
+        await mutate(caller, "test_broadcast", "receipt-with-broadcast", {}, change)
+    assert delivered == ["Committed before broadcast"]
+
+
+async def test_flow_selection_waits_for_exact_response(mcp_http, monkeypatch):
+    from mcp_server import workspace
+
+    original = workspace.execute_flow
+    errors = []
+
+    async def capture(*args):
+        try:
+            return await original(*args)
+        except Exception as exc:
+            errors.append(repr(exc))
+            raise
+
+    monkeypatch.setattr(workspace, "execute_flow", capture)
+    from core.profile_context import ProfileScope
+    from database import Flow
+    from database_registry import get_database_registry
+    from flow_runtime import create_flow_directory, get_flow_program_path
+    from mcp_server.access import access
+    from mcp_server import jobs
+
+    program = """from stimma.flow import flow, output, code, phase, hitl
+@flow(name="MCP selection", outputs={"result": output("str")})
+def program():
+    with phase("Choose"):
+        candidates = code(lambda: ["first", "second"], inputs={}, output_type="list[str]")
+        return hitl.select(candidates, count=1, instructions="Choose the second option")
+"""
+    caller = await access.authenticate("default", "test-credential-one")
+    with ProfileScope("default"):
+        async with (
+            get_database_registry()
+            .get_database("default")
+            .async_session_maker() as session
+        ):
+            flow = Flow(name="MCP selection")
+            session.add(flow)
+            await session.flush()
+            create_flow_directory(flow.id)
+            get_flow_program_path(flow.id).write_text(program)
+            await session.commit()
+            ref = access.ref(caller, "flow", flow.id)
+    await rpc(mcp_http, "access_open")
+    accepted = body(
+        await rpc(
+            mcp_http,
+            "flows_run",
+            {
+                "flow_ref": ref,
+                "program_version": hashlib.sha256(program.encode()).hexdigest(),
+                "request_key": "flow-choice",
+            },
+        )
+    )
+    try:
+        async with asyncio.timeout(5):
+            while True:
+                result = body(
+                    await rpc(mcp_http, "jobs_get", {"job_ref": accepted["job_ref"]})
+                )
+                assert result["state"] not in ("succeeded", "failed"), errors
+                if result["state"] == "input_required":
+                    break
+                await asyncio.sleep(0.01)
+        history = body(
+            await rpc(mcp_http, "chat_history", {"chat_ref": accepted["chat_ref"]})
+        )
+        assert history["items"] and history["items"][-1]["type"] == "hitl_request"
+        args = {
+            "job_ref": accepted["job_ref"],
+            "controller_version": result["controller_version"],
+            "interaction_ref": result["interaction"]["ref"],
+            "version": 1,
+            "response": {"choice_indices": [1]},
+            "request_key": "choose-second",
+        }
+        response = await rpc(mcp_http, "interaction_respond", args)
+        assert not response.get("isError"), response
+        assert body(await rpc(mcp_http, "interaction_respond", args)) == body(response)
+        result = await wait_job(mcp_http, accepted)
+        assert result["state"] == "succeeded", result
+        assert result["result"]["outputs"][0]["value"] == "second"
+        args["request_key"] = "stale-question"
+        assert (
+            body(await rpc(mcp_http, "interaction_respond", args))["code"]
+            == "control_changed"
+        )
+    finally:
+        for task in list(jobs._tasks.values()):
+            task.cancel()
+        await asyncio.gather(*list(jobs._tasks.values()), return_exceptions=True)

--- a/backend/utils/websocket.py
+++ b/backend/utils/websocket.py
@@ -1,6 +1,9 @@
 """WebSocket connection management for real-time updates."""
 import asyncio
 import json
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from copy import deepcopy
 from core.logging import get_logger
 from typing import List, Dict, Optional, Callable, Awaitable
 from fastapi import WebSocket
@@ -8,6 +11,29 @@ from fastapi import WebSocket
 from core.profile_context import get_current_profile
 
 log = get_logger(__name__)
+
+
+# A mutation can defer its own broadcasts until its database receipt commits.
+# Child tasks use normal delivery instead of inheriting an abandoned buffer.
+_broadcast_buffer = ContextVar('broadcast_buffer', default=None)
+
+
+@asynccontextmanager
+async def defer_broadcasts():
+    events = []
+    token = _broadcast_buffer.set((asyncio.current_task(), events))
+    try:
+        yield
+    except BaseException:
+        raise
+    else:
+        _broadcast_buffer.reset(token)
+        token = None
+        for manager, event, data, include_profile in events:
+            await manager.broadcast(event, data, include_profile)
+    finally:
+        if token is not None:
+            _broadcast_buffer.reset(token)
 
 
 def _payload_log_metadata(data: dict) -> dict:
@@ -91,6 +117,10 @@ class WebSocketManager:
                             for client-side filtering. Set to False for truly
                             global events (like processing_stats).
         """
+        pending = _broadcast_buffer.get()
+        if pending is not None and pending[0] is asyncio.current_task():
+            pending[1].append((self, event, deepcopy(data), include_profile))
+            return
         if not self.active_connections:
             log.debug(f"No active WebSocket connections to broadcast '{event}' to")
             return

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2,10 +2,16 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'darwin'",
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
@@ -98,6 +104,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -108,15 +123,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "3.7.1"
+version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/99/2dfd53fd55ce9838e6ff2d4dac20ce58263798bd1a0dbe18b3a9af3fcfce/anyio-3.7.1.tar.gz", hash = "sha256:44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780", size = 142927, upload-time = "2023-07-05T16:45:02.294Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/24/44299477fe7dcc9cb58d0a57d5a7588d6af2ff403fdd2d47a246c91a3246/anyio-3.7.1-py3-none-any.whl", hash = "sha256:91dee416e570e92c64041bd18b900d1d6fa78dff7048769ce5ac5ddad004fbb5", size = 80896, upload-time = "2023-07-05T16:44:59.805Z" },
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
 [[package]]
@@ -604,17 +619,18 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.104.1"
+version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/d8/002e0ba7cf848a981b3ee92aaf5aa396c5700b0d7dec5d060031432a87d8/fastapi-0.104.1.tar.gz", hash = "sha256:e5e4540a7c5e1dcfbbcf5b903c234feddcdcd881f191977a1c5dfd917487e7ae", size = 11295150, upload-time = "2023-10-30T10:07:39.105Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/4f/0ce34195b63240b6693086496c9bab4ef23999112184399a3e88854c7674/fastapi-0.104.1-py3-none-any.whl", hash = "sha256:752dc31160cdbd0436bb93bad51560b57e525cbb1d4bbf6f4904ceee75548241", size = 92862, upload-time = "2023-10-30T10:07:35.636Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
@@ -947,38 +963,45 @@ wheels = [
 
 [[package]]
 name = "httptools"
-version = "0.7.1"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/08/17e07e8d89ab8f343c134616d72eebfe03798835058e2ab579dcc8353c06/httptools-0.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:474d3b7ab469fefcca3697a10d11a32ee2b9573250206ba1e50d5980910da657", size = 206521, upload-time = "2025-10-10T03:54:31.002Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/06/c9c1b41ff52f16aee526fd10fbda99fa4787938aa776858ddc4a1ea825ec/httptools-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3c3b7366bb6c7b96bd72d0dbe7f7d5eead261361f013be5f6d9590465ea1c70", size = 110375, upload-time = "2025-10-10T03:54:31.941Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/cc/10935db22fda0ee34c76f047590ca0a8bd9de531406a3ccb10a90e12ea21/httptools-0.7.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:379b479408b8747f47f3b253326183d7c009a3936518cdb70db58cffd369d9df", size = 456621, upload-time = "2025-10-10T03:54:33.176Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/84/875382b10d271b0c11aa5d414b44f92f8dd53e9b658aec338a79164fa548/httptools-0.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cad6b591a682dcc6cf1397c3900527f9affef1e55a06c4547264796bbd17cf5e", size = 454954, upload-time = "2025-10-10T03:54:34.226Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e1/44f89b280f7e46c0b1b2ccee5737d46b3bb13136383958f20b580a821ca0/httptools-0.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eb844698d11433d2139bbeeb56499102143beb582bd6c194e3ba69c22f25c274", size = 440175, upload-time = "2025-10-10T03:54:35.942Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/7e/b9287763159e700e335028bc1824359dc736fa9b829dacedace91a39b37e/httptools-0.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f65744d7a8bdb4bda5e1fa23e4ba16832860606fcc09d674d56e425e991539ec", size = 440310, upload-time = "2025-10-10T03:54:37.1Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/07/5b614f592868e07f5c94b1f301b5e14a21df4e8076215a3bccb830a687d8/httptools-0.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:135fbe974b3718eada677229312e97f3b31f8a9c8ffa3ae6f565bf808d5b6bcb", size = 86875, upload-time = "2025-10-10T03:54:38.421Z" },
-    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
-    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
-    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
-    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
-    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
-    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
-    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
-    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
-    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
-    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
-    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/c3eedaef57de65c3cc5f8dc244cf12d09c84ad258a479055aad6db23206c/httptools-0.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ed377e64805bdba4943c82717333f8f8603a13b09aff9cead2717c6c817fb168", size = 208428, upload-time = "2026-05-25T22:16:59.717Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/94/dfe435d90d0ef61ec0f2cc3d480eef78c59727c6c2ce039f433882f6131a/httptools-0.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9518c406d7b310f05adb1a37f80acabac40504a575d7c0da6d3e365c695ac20d", size = 113366, upload-time = "2026-05-25T22:17:00.795Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d4/13025f1a56e615dcb331e0bbe2d9a1143212b58c263385fc5d2e558f5bac/httptools-0.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:57278e6fa0424c42a8a3e454828ab4f0aff27b40cddf9679579b98c6dce6a376", size = 464676, upload-time = "2026-05-25T22:17:02.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/95/4c1c26c0b985f8a3331682d802598f14e32dc41bf7509266eb2c04ad4801/httptools-0.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbb8caadb2b742d293169d2b458b5c001ef70e3158704aa3d3ef9597624c5d1d", size = 464235, upload-time = "2026-05-25T22:17:03.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/82/6735be2b0ca527718c431cdb8e5f70c3862c0844a687df0f572c51e11497/httptools-0.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:52dd695b865fe96d9d2b16b64a895f3f57bf3cb064e8383cd3b5713a069e8085", size = 449809, upload-time = "2026-05-25T22:17:04.443Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f9/5811c74f37a758c8a4aa3dc430375119d335947e883efc4664d8f3559a41/httptools-0.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:20b4aac66ff65f7db06a375808b78f42a94970aa22e826b3cb2b43eb09174124", size = 452174, upload-time = "2026-05-25T22:17:05.476Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/94/97b75870dea07b71e3ec535cebe525b08d723152e4c7d13fa887e51f4de2/httptools-0.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:a1b4c8e7a489a0d750d91894e9a8cdc295838f1924c0ca903ae993456fddec07", size = 90991, upload-time = "2026-05-25T22:17:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/14/88/1d21a36da8f5cb0fa49eafd4b169eba5608d57e75bbcf61845cbc6243216/httptools-0.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:880490234c10f70a9830743097e8958d6e4b9f5a0ffc24515023afeef984054d", size = 208247, upload-time = "2026-05-25T22:17:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/cc4feea2945cb3051038f090c9b36bd5b8a9d7f5a894a506a8983e33fd1c/httptools-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5931891fb7b441b8a3853cf1b85c82c903defce084dd5f6771ca46e31bf862c5", size = 113064, upload-time = "2026-05-25T22:17:09.136Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b15fc622b0f869d19207c4089a501d9bcc63ca5e071ffdd2f03f922df882dcb2", size = 523851, upload-time = "2026-05-25T22:17:10.106Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:425f83884fd6343828d8c565f046cb72b6d19063f6924093e11bcd8e1548cd09", size = 518842, upload-time = "2026-05-25T22:17:11.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2d/0c9ac76dd2c893841fbf6498d6acec4f2442e1b7067f6e3e316a80e494e8/httptools-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7c3c97f4311c7be57e2986629df89d49cb434dbff78eafcd48c2bff986b15a", size = 501238, upload-time = "2026-05-25T22:17:12.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/42/906adc91ae3a5fa9c59c0a2f21c139725bd7e5b41ae6acd485cd14123ebf/httptools-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a1afd7c9fbff0d9f5d489c4ce2768bd09c84a46ddefc7161e6aa82ae35c85745", size = 509567, upload-time = "2026-05-25T22:17:13.842Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0b/4240efeb672751ee5b9b380cb0e3fdc050bc05f68adc7a8aefc4fcd9a69a/httptools-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd96f29b4bab1d42fa6e3d008711c75e0f79e94e06827330160e3a304227f150", size = 90918, upload-time = "2026-05-25T22:17:15.155Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/8cfcabc5546e8022f168be28bcdaa128a240a0befdd03b59d558b4f18bd6/httptools-0.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:614ceea8ea606848bece2338ac03b3ce5324bcb4be8dc7d377ed708012fa4db8", size = 205148, upload-time = "2026-05-25T22:17:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0e/0fb14848c19a686c8062ff9067c1a48793e3224b47bc5b201535b6036fce/httptools-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d689918c15a013c65ef52d9fd495d766893ab831a2c8d89f2ac5940a5df847c", size = 111368, upload-time = "2026-05-25T22:17:17.586Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/46f1cecf06b9bbde8e4b8c88034ac7908989e5ff7a3a388ef38392949c1f/httptools-0.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eb3028cca2fc0a6d720e52ef61d8ebb62fcbfeb1de56874546d858d3f25a26b7", size = 486447, upload-time = "2026-05-25T22:17:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/258bfc0837221f81d9725c45f9b948a6a6b2994a147a4fb66e85100c668f/httptools-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88bdd940f2b5d487b4d032c6afa5489a7dc4694410d43de3c38c4fb3af0dc45d", size = 482448, upload-time = "2026-05-25T22:17:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ab/d1cef3b5523f4d272a70f42a776c3169a2dddfe3a54de4b2ce4a36341528/httptools-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a43c9dd399758ccc0531acb0a3c4a6c299ee893ee9400e9c893b7bdcfae0681", size = 464460, upload-time = "2026-05-25T22:17:20.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5d1d072442277bb2b3434e0e60690b8e8c23840ef7de8b6ea54040a536d3/httptools-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683", size = 471312, upload-time = "2026-05-25T22:17:22.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/66/b96623b27e51a68199ef4efdda0613cced9233fe3062ac74e50749c5ad37/httptools-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:7685df791fad561384bfb139e77fde27a1ffd93134e016f95a0db424ffbf77b1", size = 90117, upload-time = "2026-05-25T22:17:23.074Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/12/fa3fbf5f9517b273edea2dc982aa82a8c634091e67c590792b729017bc6f/httptools-0.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:de242a49b5d18e0a8776e654e9f6bf6d89f3875a5c35b425a0e7ce940feb3fd6", size = 206183, upload-time = "2026-05-25T22:17:24.004Z" },
+    { url = "https://files.pythonhosted.org/packages/30/fc/5e7c4cb443370f2090a3aba0453a07384d29ff66b7435bb90e77e1037599/httptools-0.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:159e9ab5f701ccd42e555a12f1ad8ff69702910fc1c996cf2bb66e5fcb7a231b", size = 112079, upload-time = "2026-05-25T22:17:25.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/771bd891eb0f236f32145d6a1775777ec85745f3cc983a1f23d1a3b8ddfe/httptools-0.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4a9f1707e4823d54dfec6c33fa3697d302aed536ed352a7ebb5a061ddb869d0", size = 481596, upload-time = "2026-05-25T22:17:26.186Z" },
+    { url = "https://files.pythonhosted.org/packages/62/42/94e15bc68ce3d423243c45d7f1b0c7561f13844f97dc52ae23182fb65628/httptools-0.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d76ad7b951387e3632c8716a9bb03ac5b45c5f16119aa409db0459520887944e", size = 480865, upload-time = "2026-05-25T22:17:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7c/fe2980fc03723272e30f135b62360b075f513dfe7cc73aef36c7f04012bd/httptools-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a3b7387147361c3fd47a0bde763c5c91b5b4cd4dc9989b8ece84ff436c99843b", size = 463189, upload-time = "2026-05-25T22:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/47fc5fff68acd1bfa20b4734059c9a06cadb88119dcd5258b5b0d21d91c8/httptools-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f256d6ce930c52ca1cb2a960b7da03548c454e7d28b06059ad41bfe789036ce0", size = 466610, upload-time = "2026-05-25T22:17:29.816Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bd/07b13c93ffd9bec9546e0d43f8e19378dd696dbd278511406bc07371ef1f/httptools-0.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:19d1ee275bb59ba2643ba9a3a1e51cc0c788caf2b8df506368e03f56fdd08527", size = 92705, upload-time = "2026-05-25T22:17:31.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c4/121648f68ce066d7bd762d6b6d97e620847642d38d54f3d90ff11d947629/httptools-0.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:de1ed58a974e75d56560acc7e7fed01a454994429456f65209789992e41f2568", size = 215023, upload-time = "2026-05-25T22:17:32.401Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b0/312a062ae741ae3e8baa8c8bf20be81b2e67337b259ab4349bebc7b6142e/httptools-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e93c227b595c6926c1acee96891dd9da4be338cfbe82e5cd3bb9d8dd7dc4ac0b", size = 117405, upload-time = "2026-05-25T22:17:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/37/fccd705f795386bb05bf413012fecff2a33e5aa8c2f069096de3e9fd8702/httptools-0.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2a021c3a8e65cc125390d72f59b968afca3bdcaff25bd67965e0a055a14946ca", size = 558497, upload-time = "2026-05-25T22:17:34.732Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/39/f172e8003576de35f5ba77ff417cf0e34429d35dc014deef15afa337a72c/httptools-0.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48774d39cbb70e2b1f71f88852a3087ae1d3a1eb80482bb48c13067ab080c14f", size = 571585, upload-time = "2026-05-25T22:17:35.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b9/f5564760af99f3dbbf3f9104dc00e5da27e96cf433c6bdcf77617f70bf3f/httptools-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:88eead8ec8680a9f146c655bc88445a325bd7921cfd8194c7337e9467282427d", size = 543297, upload-time = "2026-05-25T22:17:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/99/67/8d9f2c313618e161b82f3873188e7196126da1d6e29688df40eb3997c77a/httptools-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c032fa028f46871ec7e1fc59fc15e8023eab3e6bbe6ece786a1611719a5d081", size = 539535, upload-time = "2026-05-25T22:17:38.032Z" },
+    { url = "https://files.pythonhosted.org/packages/48/63/b906c01e53f50d432c0defe43ce52764a111dc1bdd028bafbeb54dcfd008/httptools-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:384c17174464c8e873398b7af24f0b1f44d992c820328413951a625323155d77", size = 108209, upload-time = "2026-05-25T22:17:39.473Z" },
 ]
 
 [[package]]
@@ -994,6 +1017,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -1081,6 +1113,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1344,6 +1403,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.29.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/48/0bb26fdfe7ac16875f534a101ce2405eae192bdef37e7451f2f4507c13ec/mcp-1.29.1.tar.gz", hash = "sha256:1967ba4c315f7a375146209949f45950d18b0efd2f913d7cf3400bc723ee5f04", size = 646823, upload-time = "2026-08-24T18:30:41.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/04/d6b4fb82eefe9e81807aabca1ac98f460ae0883974b83a997aaa20c52545/mcp-1.29.1-py3-none-any.whl", hash = "sha256:b6310eeb59153300c4ab8b9aec4c52f4819a2d6a8e429eb43d908bed7c783648", size = 224653, upload-time = "2026-08-24T18:30:39.573Z" },
 ]
 
 [[package]]
@@ -1880,66 +1964,133 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.5.0"
+version = "2.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/07/39d2b5c652a2cfdda6dd4d33a2eae345782f3d5c6e2f7a92c92d5da52b33/pydantic-2.5.0.tar.gz", hash = "sha256:69bd6fb62d2d04b7055f59a396993486a2ee586c43a0b89231ce0000de07627c", size = 677119, upload-time = "2023-11-13T17:17:49.17Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ef/fc4f868f4e2cee79f863883abffceff107875f569b848507319842d2a681/pydantic-2.13.5.tar.gz", hash = "sha256:51a9c5f7b2f8e636f04c6cada605d9b6a3bf1348fdf945a3d8869b19bba0ee08", size = 845750, upload-time = "2026-08-28T14:04:00.916Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/10/ddfb9539a6e55f7dfd6c2b9b81d86fcba2761ba87eeb81f8b1012957dcdc/pydantic-2.5.0-py3-none-any.whl", hash = "sha256:7ce6e766c456ad026fe5712f7bcf036efc34bd5d107b3e669ef7ea01b3a9050c", size = 407491, upload-time = "2023-11-13T17:17:45.239Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/47/c95ffc2009878c7aac0c5e08528022dcb885933252a88b5f170058014464/pydantic-2.13.5-py3-none-any.whl", hash = "sha256:346a034f080da3755d8e9cb5e00e8b07de1d39e4f6e2c87d8ab7cafa0b269a73", size = 472589, upload-time = "2026-08-28T14:03:59.136Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.14.1"
+version = "2.46.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/f2/0be79498e0f645fff8cd58c0013f4d03e17a54047e703efb30a200a4a9b2/pydantic_core-2.14.1.tar.gz", hash = "sha256:0d82a6ee815388a362885186e431fac84c7a06623bc136f508e9f88261d8cadb", size = 359077, upload-time = "2023-11-09T13:24:55.704Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/f9/8a06bea35ef8daf588f707784c973a7046e0034c8d8cfb08828eeffb8b75/pydantic_core-2.46.5.tar.gz", hash = "sha256:10416c15b8839ecc4ef4d0885da76da6fd0f67333a0eb8aff6d93c4b8f2910fc", size = 472262, upload-time = "2026-08-28T10:01:31.677Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/c4/a71176e4ef6fadc364b63cb80116cc8c3dc202269b0c3dbbd246c6e827d8/pydantic_core-2.14.1-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:2be018a84995b6be1bbd40d6064395dbf71592a981169cf154c0885637f5f54a", size = 1863722, upload-time = "2023-11-09T13:21:00.691Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/83/716b8dd7529d9c8487b103068bbe12313a2eda7ff609077d006e82a286b8/pydantic_core-2.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fc3227408808ba7df8e95eb1d8389f4ba2203bed8240b308de1d7ae66d828f24", size = 1739514, upload-time = "2023-11-09T13:21:02.704Z" },
-    { url = "https://files.pythonhosted.org/packages/05/3d/dd526b5b28e454c605ad4f39db4fad29c8a7e639cf1556e7383aa884bf53/pydantic_core-2.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42d5d0e9bbb50481a049bd0203224b339d4db04006b78564df2b782e2fd16ebc", size = 1830155, upload-time = "2023-11-09T13:21:04.857Z" },
-    { url = "https://files.pythonhosted.org/packages/95/d8/b165ff9787dd2f4d8c25e92e90f6e7cc974c97e0d315ba074424c18315c1/pydantic_core-2.14.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bc6a4ea9f88a810cb65ccae14404da846e2a02dd5c0ad21dee712ff69d142638", size = 1851645, upload-time = "2023-11-09T13:21:07.373Z" },
-    { url = "https://files.pythonhosted.org/packages/25/62/961244e1590b76ea0125c7465adc4bc22b52dbe52d11e91ece46767a9c9f/pydantic_core-2.14.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d312ad20e3c6d179cb97c42232b53111bcd8dcdd5c1136083db9d6bdd489bc73", size = 2006052, upload-time = "2023-11-09T13:21:09.527Z" },
-    { url = "https://files.pythonhosted.org/packages/60/e9/2584062aaf1d94d47a958305e02b10d8a8dc65700d1afb8dc91971661a14/pydantic_core-2.14.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:679cc4e184f213c8227862e57340d12fd4d4d19dc0e3ddb0f653f86f01e90f94", size = 2938897, upload-time = "2023-11-09T13:21:11.634Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/bb/574fe50b6834be052db6988cbeae88420b536177d65a77da270d4fdea2bf/pydantic_core-2.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101df420e954966868b8bc992aefed5fa71dd1f2755104da62ee247abab28e2f", size = 2050704, upload-time = "2023-11-09T13:21:14.053Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/de/33757f90dd615a14223b8c26b451b4f6ecd1ff4325be54b942a448a6189c/pydantic_core-2.14.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c964c0cc443d6c08a2347c0e5c1fc2d85a272dc66c1a6f3cde4fc4843882ada4", size = 1920289, upload-time = "2023-11-09T13:21:16.273Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/d6/31e6af2c5d4e30282e73bcfc6215cce632d42ac54de7169910f758e9f833/pydantic_core-2.14.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8276bbab68a9dbe721da92d19cbc061f76655248fe24fb63969d0c3e0e5755e7", size = 2001567, upload-time = "2023-11-09T13:21:18.496Z" },
-    { url = "https://files.pythonhosted.org/packages/83/7a/b3fcfc08b5e0b5d77ba4a6489f23c1c17b03b0ed53c5767c43da30d39111/pydantic_core-2.14.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:12163197fec7c95751a3c71b36dcc1909eed9959f011ffc79cc8170a6a74c826", size = 2134098, upload-time = "2023-11-09T13:21:20.89Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/17/8cc269838879844681db0d9e92fcea992158c6f4a880ae1c5f6ea601a3f0/pydantic_core-2.14.1-cp311-none-win32.whl", hash = "sha256:b8ff0302518dcd001bd722bbe342919c29e5066c7eda86828fe08cdc112668b8", size = 1727681, upload-time = "2023-11-09T13:21:22.929Z" },
-    { url = "https://files.pythonhosted.org/packages/15/8e/68d3a522ac31e782e3ae95ddc7b4ec4bea0f5c552a98f85abdee6696a607/pydantic_core-2.14.1-cp311-none-win_amd64.whl", hash = "sha256:59fa83873223f856d898452c6162a390af4297756f6ba38493a67533387d85d9", size = 1890264, upload-time = "2023-11-09T13:21:24.903Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/3c/39d379089d9cd85b506c4a18f5c68be7efccc9dfaea8edea864f66dd3fe7/pydantic_core-2.14.1-cp311-none-win_arm64.whl", hash = "sha256:798590d38c9381f07c48d13af1f1ef337cebf76ee452fcec5deb04aceced51c7", size = 1850567, upload-time = "2023-11-09T13:21:27.318Z" },
-    { url = "https://files.pythonhosted.org/packages/38/e5/f432d1bf9c10a0fe7bf8819ada23c68ccbf1c40ad358dac3abc126d87476/pydantic_core-2.14.1-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:587d75aec9ae50d0d63788cec38bf13c5128b3fc1411aa4b9398ebac884ab179", size = 1856037, upload-time = "2023-11-09T13:21:29.719Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/bf/13b52f568786732e807ebabe51739a4d9a2bcce5cb8f182a69b8ef987bc5/pydantic_core-2.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26242e3593d4929123615bd9365dd86ef79b7b0592d64a96cd11fd83c69c9f34", size = 1710416, upload-time = "2023-11-09T13:21:31.625Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/0d/a55c0c257aa605a4cd4376e80665a08f02fb41612d416e654da279b18bc6/pydantic_core-2.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5879ac4791508d8f0eb7dec71ff8521855180688dac0c55f8c99fc4d1a939845", size = 1824883, upload-time = "2023-11-09T13:21:33.405Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/59/8903e4324298f6c5a28d8934e6193ea0d4ed687dfc5aa1453ff0f95faf0b/pydantic_core-2.14.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ad9ea86f5fc50f1b62c31184767fe0cacaa13b54fe57d38898c3776d30602411", size = 1835090, upload-time = "2023-11-09T13:21:35.745Z" },
-    { url = "https://files.pythonhosted.org/packages/60/1a/6b90e497c8e8aa1014ccea46d93e420cd4be183058952158f2351ce33e48/pydantic_core-2.14.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:102ac85a775e77821943ae38da9634ddd774b37a8d407181b4f7b05cdfb36b55", size = 1997646, upload-time = "2023-11-09T13:21:38.382Z" },
-    { url = "https://files.pythonhosted.org/packages/06/8d/023ebb75c8daad8a0d1109948b82237284adb0be86b6fc8c5d54e9683d7a/pydantic_core-2.14.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2459cc06572730e079ec1e694e8f68c99d977b40d98748ae72ff11ef21a56b0b", size = 2991445, upload-time = "2023-11-09T13:21:40.459Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/85/6300b9bcec95d04903764afb485f2c2343e007a15fa6b7620bba0eb5715d/pydantic_core-2.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:217dcbfaf429a9b8f1d54eb380908b9c778e78f31378283b30ba463c21e89d5d", size = 2064902, upload-time = "2023-11-09T13:21:43.097Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/e7/b7e0c92bf712429ee627cbcbd15ef68b4330f0b8bcb285eed53553ecd2f4/pydantic_core-2.14.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9d59e0d7cdfe8ed1d4fcd28aad09625c715dc18976c7067e37d8a11b06f4be3e", size = 1922668, upload-time = "2023-11-09T13:21:45.131Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/c4/5638b9ad1053aeb66384e3a248ef1f37e5fcc0d5695ec9a15e4df81be54d/pydantic_core-2.14.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e2be646a5155d408e68b560c0553e8a83dc7b9f90ec6e5a2fc3ff216719385db", size = 1999542, upload-time = "2023-11-09T13:21:47.664Z" },
-    { url = "https://files.pythonhosted.org/packages/74/20/2389be6093f6ec2e9351fe0f9270b239f039c0da9e4b38cbe06e7f650b1c/pydantic_core-2.14.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ffba979801e3931a19cd30ed2049450820effe8f152aaa317e2fd93795d318d7", size = 2127246, upload-time = "2023-11-09T13:21:50.209Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/47/a0cd42721edf31556006278d34c02f1c45ddf5aa0bbd629824a4412b776f/pydantic_core-2.14.1-cp312-none-win32.whl", hash = "sha256:132b40e479cb5cebbbb681f77aaceabbc8355df16c9124cff1d4060ada83cde2", size = 1738151, upload-time = "2023-11-09T13:21:52.596Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/4a/ae0d4c98d97bd042162a9de7cea4b2f655b5876cd0557ff451eedf0778e6/pydantic_core-2.14.1-cp312-none-win_amd64.whl", hash = "sha256:744b807fe2733b6da3b53e8ad93e8b3ea3ee3dfc3abece4dd2824cc1f39aa343", size = 1864110, upload-time = "2023-11-09T13:21:54.632Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/9a/3d9f3a750a67cc3d1115c0581280025cadc1cbd55d5c60d1ba80c8de7535/pydantic_core-2.14.1-cp312-none-win_arm64.whl", hash = "sha256:24ba48f9d0b8d64fc5e42e1600366c3d7db701201294989aebdaca23110c02ab", size = 1847510, upload-time = "2023-11-09T13:21:57.252Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b6/81d2d19ea0be2c03664381b59f65fa72fc7969decedae00bc2c4ad835708/pydantic_core-2.46.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a1dee1b804ff4d11c663636cf15d2ea47e9f79cd56c033fb1cbf08924842a48f", size = 2074737, upload-time = "2026-08-28T09:57:57.711Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/18/b70da8300e292df4099684ea11b1958043580d2f50d2dc8bf7e542bdd84a/pydantic_core-2.46.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d625a186a65201c23a9e3b8ed9c47e90a026e03256608cc91851c6709096844f", size = 1921751, upload-time = "2026-08-28T09:57:59.265Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/1a/0d590341b6ffa4b4aca83508e6b8db4761aaeacfc15a25ca3815876d4797/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f8507560a9284e1370bb048ed4282012fbef4e8d109875b95e884d228552061", size = 1948231, upload-time = "2026-08-28T09:58:00.678Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/02eb35761c51f2f7b1b042d6ab4cda6600f0c8c88a2243b3f734376201e5/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f93c5fe914d75fbec9a49209b00da5f08e9e467d69da2b1510c81940cfd10be", size = 2020708, upload-time = "2026-08-28T09:58:02.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ea/f86073830e35d508cc8ddf9c3d9e6e6840fcb88d34bf726b0b4710186f27/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c767f552b21b10f774aeac128e828eafb796adfa1b666a18bf6321453c3a", size = 2194914, upload-time = "2026-08-28T09:58:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/fc36240d7791ce90939e51608568c33bfdae26202016f9770c229a487d86/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:701b2e04b560eeb4bddf7a25ab8ca476176e34fdbd9a0e18196f0d12d4685f0b", size = 2235622, upload-time = "2026-08-28T09:58:05.516Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/bc/3fa2d76b83162820a17da7f645b28d1cba99fc8e1e5fc6517067ec450fa1/pydantic_core-2.46.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49776eab08766a08dfff7012f8b422dcd7e25e43b316eedf0477c24fcfa84b7c", size = 2062091, upload-time = "2026-08-28T09:58:07.135Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/9a/095d557bb492c90cd8a70a6dd048bf793d433d03d86c81c11e912e4cd049/pydantic_core-2.46.5-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:a2468d93d181667a7abd66e1b64bb9f76f361b0fef8faddf687456453576f5ee", size = 2089904, upload-time = "2026-08-28T09:58:08.814Z" },
+    { url = "https://files.pythonhosted.org/packages/24/98/7b76b1ad10a19a617a52aaa1d80e159115af939b095e86f8e756fd52e0df/pydantic_core-2.46.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:53feb344243bb9510a9dec7bf3cf1b64d88a98af5dc7872a5160465f8b198c8e", size = 2132244, upload-time = "2026-08-28T09:58:10.435Z" },
+    { url = "https://files.pythonhosted.org/packages/20/32/7d6ca365fadba186a0c8f85de1a701663bce81efd309d9479be58687622f/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:cd5214352ae68f3b5e9af7768bdc5253695ee069675db3480518420b3be881f2", size = 2143901, upload-time = "2026-08-28T09:58:12.033Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/09/eb9a6aa57f22fd1541a9c0aa2a1f3aeef3ec65347d33e10a6da2f43e0ee9/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:9432f3598db432cb51c5b37fdbf29a60fcccc79e30d37a05022776a6bc4ab689", size = 2299425, upload-time = "2026-08-28T09:58:13.614Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/548a5bb9d4ba8cd26e26daf48052236f6b38bb61e7b7241fbc3c995719eb/pydantic_core-2.46.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8feeac04b5794e513e710af2f9c87d49f31a6dc47967bb264a1fed61a8989bec", size = 2318566, upload-time = "2026-08-28T09:58:15.199Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/20/06454d18834c02c406c9133f1a3b485305fd9ee984f9636c2f730bef6a9d/pydantic_core-2.46.5-cp311-cp311-win32.whl", hash = "sha256:892a881d5f68c2b9ea304b7a6c2c60d9343df578a311b0f86b94bc8f1ffe8129", size = 1954258, upload-time = "2026-08-28T09:58:16.813Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/718b9deb4b72453b5d8c7447a3b14cb77bef36917ef5f514e0948a4096a0/pydantic_core-2.46.5-cp311-cp311-win_amd64.whl", hash = "sha256:40375c2d05acec10323e45dfe2077ac44bc74659008614af5069034e2cfc781c", size = 2041030, upload-time = "2026-08-28T09:58:18.288Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ea/c1d1a5b72d6e1ff7f377a4d9199f6591f095beb5b409a8a5d89f7238d939/pydantic_core-2.46.5-cp311-cp311-win_arm64.whl", hash = "sha256:28a6a556cd3b6066bea827857f9d9cce027c96f776e512f544a581f9e42161f8", size = 2009234, upload-time = "2026-08-28T09:58:19.929Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3f/76358795aa7a8c6d4f36e2cb828ad1c90ee118e1393a9281664f5aade9d4/pydantic_core-2.46.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b9fe6fb92520e3fd61f2e49000b6911b188824f089b75973ea06d6267f0b476d", size = 2076516, upload-time = "2026-08-28T09:58:21.576Z" },
+    { url = "https://files.pythonhosted.org/packages/db/50/26b091836076ce4cb2fac264186936acc069e0595772cfd02a563bc4761a/pydantic_core-2.46.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a39ac25a9a2fa4072efdb429833c4a4c8009a51ff9eea3eeae131713cd27991e", size = 1922874, upload-time = "2026-08-28T09:58:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/09/f0/2a8ce3849e299d44e2d2c196b6082643a3235565a735cb51db7a6261f614/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fdc8b93a41521988916eeaa271173fcca7fa0803d62f87675aac8dcec1c8e29", size = 1951772, upload-time = "2026-08-28T09:58:25.435Z" },
+    { url = "https://files.pythonhosted.org/packages/87/46/ac0dc8bdd9e6048183a14eb127764e7ad9240021c17513074a4711b0e31e/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b98134087d9de723658d17a42c7d0da8d6e2ef08015dee7dc93889047315f5e4", size = 2031832, upload-time = "2026-08-28T09:58:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/339de5bef7be36301a2231eaa52e62163742c2281f11b5f4892bc79785cd/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e652ab17569c94bff5475520f907b7148b8c24036a8ebbe5cf7cf7493d28579a", size = 2208645, upload-time = "2026-08-28T09:58:28.948Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a0/9ff22b797724262da14427abaed4dd1d864a139693fc5e7809114376a716/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d925f3d9afd05a8c0fb3a1031463a8d59ebe5e2afad297e29c78be19e13b4e62", size = 2265935, upload-time = "2026-08-28T09:58:30.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a4/eb9409ec0736e50aa70a412f16c204ed149516846912f7e6724d4c73ee53/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fc5be0abd4a407e200d844b404e33639a554e7bd0d448e7b9ae181be4789ac2", size = 2066284, upload-time = "2026-08-28T09:58:32.289Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/02/7f6156ffc926857f1c37c07d9a388682865a81830ab6a1b637082c25e399/pydantic_core-2.46.5-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:816ff0a6550ffc06c098ccd2e0698600f9aa7da192a79eaa6f9af504a35db869", size = 2105889, upload-time = "2026-08-28T09:58:33.986Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/e781d357ebe09fc929f995700f1b3503e8897f1cece183ecb1300d4d67e9/pydantic_core-2.46.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c7ea57fc63aa7da93a1bd2d644e6577befae10c52c4e36377635eea1056a74f5", size = 2158006, upload-time = "2026-08-28T09:58:35.647Z" },
+    { url = "https://files.pythonhosted.org/packages/70/0a/644597d84ab400e50609c192120b85c9681c22d3a20461b9060a79be0a7a/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:efd62a42486f1bda5d24cb4f63d15a3c7768375fe83d36f9417b4ad7a2fb20b3", size = 2158408, upload-time = "2026-08-28T09:58:37.38Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ee/ca3b7b3a4b3769ffe9ce9432a7c9be755de9593a46d3b0d54d0409323e44/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:2bc9419666990c06d7397831f2126a1ecc3594aaa3ff7de5bf2d066802f4e07b", size = 2309609, upload-time = "2026-08-28T09:58:39.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/52/39fa1f451486019524ca685020390e7ca351832fd874530ba30c8628e6dc/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:18a09e1e1011b462f2e32774f25859ef1223d5c2b0546a633cf56654710721e0", size = 2342618, upload-time = "2026-08-28T09:58:40.89Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5e/468fc630568c61dcef3cd47ad32ffbeed9af643f49208d1ea86ab4f890c4/pydantic_core-2.46.5-cp312-cp312-win32.whl", hash = "sha256:5cb482e9e84c851f4e623fe4acc1ced89168cf1fe18f7089db4548c8f5bbb65b", size = 1939475, upload-time = "2026-08-28T09:58:42.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c9/4c19f41b84cf6b622a72fbeed7665b25d47a187d68d47d0d430c07f23268/pydantic_core-2.46.5-cp312-cp312-win_amd64.whl", hash = "sha256:5e81740c09e310f5aa5cbd3e434a01c154d4bef93241c7877b39f211d2b78ba8", size = 2043140, upload-time = "2026-08-28T09:58:44.272Z" },
+    { url = "https://files.pythonhosted.org/packages/af/dd/0c1a050299147c746e5256db16d645ab5efd4f78c59937d581a0524e74a2/pydantic_core-2.46.5-cp312-cp312-win_arm64.whl", hash = "sha256:f7b0ec93a2893de856652154d73b7ba622f26fa97726487dcac373de5f4c6084", size = 1997729, upload-time = "2026-08-28T09:58:46.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/37/5abe39a8372a61d3dc3c1338fc504281c01b32fdb3169cd7187153b56d3e/pydantic_core-2.46.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:b7ca9034437b6022f941f4857459562ee00a560b97e7cce8a0ec5a74fc6766e0", size = 2075885, upload-time = "2026-08-28T09:58:47.856Z" },
+    { url = "https://files.pythonhosted.org/packages/21/43/6323b1f8b217780454c61304bcd2b38ae4762f50754414124603ccc90bb2/pydantic_core-2.46.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f332f0e72a5a0400141f830744e141bf9f97917878dbe968669e8a7fefea78ff", size = 1922768, upload-time = "2026-08-28T09:58:49.58Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a3/c05ca796e1197618a774b01e596aeedfefc2f7d8c01ae3054e910b120e8a/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:193375f3548919d3f0b60936ca113ada3e38f264f91b9b8e0508efaad57be931", size = 1951241, upload-time = "2026-08-28T09:58:51.511Z" },
+    { url = "https://files.pythonhosted.org/packages/68/32/33bc39ac705c52cffc908e8389f9754fdb208aea5c69cceddf4eb3ce99af/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:79bdfa52f843137045b2d081cc05c120ba6665d29b7559c2c47690906f39279f", size = 2031975, upload-time = "2026-08-28T09:58:53.166Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/70/2333e885c0f6a67bc105c5916965dac9b57f2718ee20d81d1a06a4ebdc13/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:24922243639cbdac66c75fcb6fd6495a9cb52b213d62f9a0d16f0310b1ff8038", size = 2208542, upload-time = "2026-08-28T09:58:55.017Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ea/296debfb4264207bbda5936133892e027c0a58875ad53ebd512fba8ec3a2/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c76fe65e607be28c7fd4d56fc3c42b1583aa058ce3408b7ad0fd540171d31f9f", size = 2264692, upload-time = "2026-08-28T09:58:56.767Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/9e4de77a6271e07a76d2d58b11c091a979c191ed2939bf80067568b369d2/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f7b393a8b3da82f5c1fc0751e6d01ac6c55b93c18226a60bdfba4a724efafd1", size = 2066633, upload-time = "2026-08-28T09:58:58.531Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/db/f9e9d0c97445987b2084823d5c240de88087338f04fc2cfaa2df186b8049/pydantic_core-2.46.5-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:7ac031912d54f3d83ef3b3eb98dfabc1608802e2202263d25957eeed40b94761", size = 2105235, upload-time = "2026-08-28T09:59:00.421Z" },
+    { url = "https://files.pythonhosted.org/packages/07/c5/79169b047b3b2c3e99e04bc76372af9637e0bf6db638274fa927df96369e/pydantic_core-2.46.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:837b396ca3d7b74091ca623f6cbd8351bd42d670a79c2683e79fb089f06a2de5", size = 2157367, upload-time = "2026-08-28T09:59:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b5/ba6057afb7c291bd449f51b867f95aef2072941c4ce4e5c31d6ffd132d3b/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:5ee239d575f80b08eca11f6e20f90c4c695de7825c67eefe6091fbf20dda648e", size = 2158420, upload-time = "2026-08-28T09:59:04.2Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/2057abecaafdc22912afa819603a51f0a62d40643b7c4871c51721fea9be/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:e80675d75ae2cd14372cb65cad5400d9347a3d3f6c13000183f22dfd027283ed", size = 2309588, upload-time = "2026-08-28T09:59:06.048Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9d/881156dc404e27479c4246128d73538464cab4a239bec61995e227644c30/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:9c4b71f10dd532fb7a5cbc8f58707779e64f03a258c2bf8bfbaecfcd9970b519", size = 2341866, upload-time = "2026-08-28T09:59:08.539Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/38/d66f443a259f84d13babdceae568e572b0ed26da17ca5d0a649ebb110a67/pydantic_core-2.46.5-cp313-cp313-win32.whl", hash = "sha256:97bf8de4d541598c94a59344eeb988a94c08ff76b5723c41f6567ec18c7892ea", size = 1938580, upload-time = "2026-08-28T09:59:10.402Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/1e/1d5371213f4cc9a7ed70c0bfcc7911de22311ee99a662a56077d7292d2ac/pydantic_core-2.46.5-cp313-cp313-win_amd64.whl", hash = "sha256:15f4a94963c95accac15b7b657bb177d3ad82bb90b0d0526d9a9b85079925db5", size = 2041980, upload-time = "2026-08-28T09:59:12.396Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/48/4222d90b1c67568bace4dec6dca6271449c66de3595d72b6d098f5fde597/pydantic_core-2.46.5-cp313-cp313-win_arm64.whl", hash = "sha256:d22a945598fb91236b4dd793a6e42e4f3dd7740bb5aace5ebd7d4c08d13bb575", size = 1997213, upload-time = "2026-08-28T09:59:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8a/14596f2a8367da50cf7cbac48169ee5d9c8e11d486a3b527082384630c72/pydantic_core-2.46.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c1c43ad4339643d70ebb8124e1305a7dab423001eff58bb41a0f731adbc98355", size = 2074081, upload-time = "2026-08-28T09:59:16.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d5/d8a4eb6d6c7f66b91dd37c576d76e9e60fba900caf5372c17bcf949febc2/pydantic_core-2.46.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1a353f84de772f423b5ffb11d7ae352fbbef0f446f3c0b0af0f8236d7233606e", size = 1920497, upload-time = "2026-08-28T09:59:18.065Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/26/092079428f86e927e030b2c0ced87df69dbb1c875cdeaa67bf42ea2be746/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5086029a57366b8cf81b130a43908738095c270c21a8d7f0e8bdfdb89718e2f3", size = 1952130, upload-time = "2026-08-28T09:59:20.476Z" },
+    { url = "https://files.pythonhosted.org/packages/08/c3/8ec0e290a9ebaebd64047bf5fda94be835c6b1551b02437e4b76778fbcd7/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:46c25dda9d092a06c08db76ffe0a197107904d0dfac653f7d5306bbcd6d6119c", size = 2026371, upload-time = "2026-08-28T09:59:22.227Z" },
+    { url = "https://files.pythonhosted.org/packages/01/72/4fd20ad520fb8da0157f95b27a7eb05a72790ef08138e7701ac972c342ea/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:37ea7b83c935e5b0d68c9449b82651accf78a10828b2c02b2f2d9e9496446c21", size = 2202822, upload-time = "2026-08-28T09:59:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b0/d16e0771206b29314f0d52198b720be21e8a99ab2bf11e3bc0d7c9cebdff/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e64e88d5585bea9ce95861079de72006c7fa6d3df4e3a3b65ba31eb979c15c9f", size = 2262756, upload-time = "2026-08-28T09:59:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9b/59634b7ac631c63b2a37760eb6943af3e29573d6b59a4abc5e7f019d4cee/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d510bac3ee52247af28ed4bb18a1e799f040ac60fd2bf5ccd4c92f1fbe786f", size = 2068352, upload-time = "2026-08-28T09:59:29.044Z" },
+    { url = "https://files.pythonhosted.org/packages/08/7c/570abb1ad2155348dc754ea91be22e5aaa18eb6d69a6068f7c6f2679a6ed/pydantic_core-2.46.5-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:a2a5e1d0ff29adddc9f6d6821a66302e4493f8ca898b715b6b1182c2c201ea0a", size = 2104777, upload-time = "2026-08-28T09:59:30.95Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/25/5bf74adc65a1ac5b7be3f6cb0bcb5433615c1598a801c19d830d84c98ded/pydantic_core-2.46.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:03b9666e41e35d8909852ba191a0607520f81b74eaf12ccf8737005dbb313821", size = 2156312, upload-time = "2026-08-28T09:59:32.604Z" },
+    { url = "https://files.pythonhosted.org/packages/90/6a/2ef38830675e050121040618135564ed56b860b45433b02d9b4ebece46f3/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:a91c17edf6eea2402cb5457b4c89e99bc5ed1004aa34c4adf1d4258c1a5c22c2", size = 2150067, upload-time = "2026-08-28T09:59:34.453Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/a7dbb03a14a64c2a4621f989c615ed9a892535a6cad938fc27079f919d80/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b49924c73a235e969511bf2aabdff3beebf9820931f646c80274d5d780010c47", size = 2304516, upload-time = "2026-08-28T09:59:36.194Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f8/6bb4c4b80e8a6fde1904c64a51c62a1d04fcdfa3ea521a66b2ddefa1d885/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:2cbd9a5eff05e51c447c34dfa4632145b26b09120cf04bd0c871e44c1a5e1c9a", size = 2335223, upload-time = "2026-08-28T09:59:37.931Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/80/f46b8c681195190b2c1f1c7c0a81abce60663e987613e09ef64d433dd96b/pydantic_core-2.46.5-cp314-cp314-win32.whl", hash = "sha256:2d5d76654becf5efd62c9e51c3756c67b49498b0c9a40884934c40807adbd074", size = 1934827, upload-time = "2026-08-28T09:59:39.836Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/3c/60674207246bc0a4009d2391b7c7251c7159f279c8d2ab8aae8ef46f3dee/pydantic_core-2.46.5-cp314-cp314-win_amd64.whl", hash = "sha256:fa10ef4112775900e7a0661068635eb67b2ab824fbde764de6e0e21982a93db0", size = 2042648, upload-time = "2026-08-28T09:59:41.792Z" },
+    { url = "https://files.pythonhosted.org/packages/69/0c/117c562c7c1babdf44576b72a5e496906506c93690387ecfbca7c729ae2e/pydantic_core-2.46.5-cp314-cp314-win_arm64.whl", hash = "sha256:045ab3b6d308439e32b81cc173bba5b9018bc6ed896afd0c65b3b009b1699af5", size = 1989652, upload-time = "2026-08-28T09:59:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/66/9336ae58f9eb68c41d121894e52c4c89eccb07eb8f602a04ee9c3f37736a/pydantic_core-2.46.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8816f3d218beb4b787de5c9759c259b8fa61f9dec42dc7811f320a33771778b7", size = 2065829, upload-time = "2026-08-28T09:59:45.364Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/02/bc19b47a96c2d3109760711acf22369e56bd7e405ca52f7ade164d2ead57/pydantic_core-2.46.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bce57638e08ac148e5778cce7feb968307a727d66f8e2274a543d0cf0c9ad6a3", size = 1905716, upload-time = "2026-08-28T09:59:47.18Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a4/70b47c0509923dd98ccfed04fb3e32ea3849c82a0ff2205bb41009b43c00/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:976e1128455aa595ea04c79ccfedff1aaeab96ee013fcc916bed120c4f0ad94f", size = 1934216, upload-time = "2026-08-28T09:59:49.241Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ab/aa03b65f7bb198585edf806b906c3223ecf1795543e39e23aec4cce27ad2/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b891faeedeafba41b2983e5001a81b6a915b69544c7e7570d1989ce1c36ac7", size = 2010635, upload-time = "2026-08-28T09:59:51.692Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/8b/0da06343f30b84ec549aafd309c6456223d5dc8bd36af504c573faad561d/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f194189415698233dd1114a093a9b56e61e2c57e11b469be3b0506f46f0771c", size = 2209369, upload-time = "2026-08-28T09:59:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/844c4defaa34a3df66eb9257087d121d70c201298b96abdf9f492fc2f1bf/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82a36973cf8a2ef5406f4fe2edbf8ed0c99629535d959e0b100c76a32535a111", size = 2253238, upload-time = "2026-08-28T09:59:55.484Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/64/a4e536cb16d7f61a7fd3120b46c577fc7fa7325992f69c4f52bc786d77d8/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdbb78909f52b981d3b2d56b97328d71eb0b974c36bd77c920123a7ebb192829", size = 2065740, upload-time = "2026-08-28T09:59:58.038Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/75/aaa38c6bc2d085f6605b34eabdc6a8a4e0b2e61fc9c8e6e52b28e97b3125/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:52e24eacdb536cade636aa90fb851835222becff8484b7001fdc78cb0290f2aa", size = 2087425, upload-time = "2026-08-28T09:59:59.898Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ae/fcab4cfc39aba3689e1d20c8b5250ad280957022c09af2ed9cd585602a5e/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:37ae34309d7bd8c0d61ab839668058f2a7962ea1fc51d105d2db228fe0618034", size = 2139306, upload-time = "2026-08-28T10:00:03.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f4/f1d03a4bc9d9acbc62f4d742b8a319af52f71885079868b2ff8e48a651ee/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:0cdbada856a1c69a7624a64d3d9aefe79300bd6ef827b43a4f265010b9b55184", size = 2144589, upload-time = "2026-08-28T10:00:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f3/7a53bb1356de514a4cd295f25b6ac39237895620c0462d2592b76c16e114/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:545f26c504b27c3758439a5e6d9349931f0a04f855668d5fe323c89e82300a38", size = 2288882, upload-time = "2026-08-28T10:00:07.931Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/94/5a81583660c175c59d49ffb09f4b3a44debeaf86a19fca664ae1cdd9ee32/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:ff218293c9c806138dca139765e3b067621be52bcd93cdc14c7711be7ddc90a9", size = 2335210, upload-time = "2026-08-28T10:00:10.177Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9f/5d685c2693b972d1a59c998586e8823712b66603aeff47ee60a4bdaafd37/pydantic_core-2.46.5-cp314-cp314t-win32.whl", hash = "sha256:97cf3eb53a8cccacf9d46686a0926186c9bfb5574f2ed66d3639d5fe117cd3a9", size = 1921180, upload-time = "2026-08-28T10:00:12.35Z" },
+    { url = "https://files.pythonhosted.org/packages/70/12/5c94ee16d65a37a15f9e869f5e6256df111154491173801a4c5e800ab548/pydantic_core-2.46.5-cp314-cp314t-win_amd64.whl", hash = "sha256:d2f9fc07a8042a8f95925b35c4f04f469707c981fc33245b6ca187cf5d2dd290", size = 2020515, upload-time = "2026-08-28T10:00:14.774Z" },
+    { url = "https://files.pythonhosted.org/packages/63/19/67830dda664e6bdf9285ee2e40f355d0d7d6b92aa0c42e8d217bb8d33d36/pydantic_core-2.46.5-cp314-cp314t-win_arm64.whl", hash = "sha256:acf8a67ba51f4ca9ddbd0e6b3000a65ac51ab734661778b3e7ba64d99a710f2f", size = 1989276, upload-time = "2026-08-28T10:00:16.984Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1e/ecca01fce348f7e8afa9572441ff6f7d1cc70d21e4859f33944d10877e1e/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:c14ad3bdc85ee7f318742c457ca3968a92126d144b15721c759033bfb06296c2", size = 2075342, upload-time = "2026-08-28T10:00:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/4c/af80c7a8032dfc897040ad5cb772bebde529a381186499e6e29987f23f8c/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0bddb4020d8f04175865ccd17eff3040874fc11fb593f424edb452653b4b947c", size = 1907219, upload-time = "2026-08-28T10:00:53.438Z" },
+    { url = "https://files.pythonhosted.org/packages/be/3e/54d89e2b092e778716bf6153634ef479e955f48c261090be23aa1e0fb0b5/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2471fd51c61c610e1dcf7de44d7299283661654d11264ab4802b303368d69c47", size = 1953393, upload-time = "2026-08-28T10:00:55.58Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/89/828ee90cda28ce17bdefaa3a6eaf74fe430e113295a10e6126beca559d6c/pydantic_core-2.46.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b10ec717381bdbfafef34607824db4c91de69ff085e4fca3b2af91b4fa17e68a", size = 2099024, upload-time = "2026-08-28T10:00:57.794Z" },
+    { url = "https://files.pythonhosted.org/packages/df/dd/053c2e4303f791f3b8f8a14ab0b22008e8eb21d868c0c90b4f9be705b76a/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:013d6f3483d81e02e7c328831808f336c8596ee33b4bd4026b9ffb1e960b8942", size = 2062540, upload-time = "2026-08-28T10:01:00.318Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/dd/a18df751a5e37dd51bfad7f68e766999125bebe68c9e1d10a493ad01bd63/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:e9c134bb666dd54b778b9fc0d2b50cbb7f979b9e3716f26a88c9ab3b6fc1dd0f", size = 1902040, upload-time = "2026-08-28T10:01:02.529Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/13/01d40f9d07ce8a779fd6e0bd8ad4fba91309500dd67b869e2e219d261a6d/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:347ec774390c87326a2e4929d58d3f7e8763a104d5d35f4cd595a4c952366433", size = 1967479, upload-time = "2026-08-28T10:01:05.004Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/04/c81d4841331c2178b6fb09ae225425e110ed72d990c9fe556c4ec03d1013/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e24d8f05fa2d28513d94e877e9c75ad66175376209b3977f916e240e623193c", size = 2111034, upload-time = "2026-08-28T10:01:07.345Z" },
+    { url = "https://files.pythonhosted.org/packages/20/21/22102e9950b3049526d20e811b95396508377d87651edd2b80d2b3d28659/pydantic_core-2.46.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ab4b66edffb32d9e951efb3814bd104b8367a7501b81b955cacb5726d897389f", size = 2071333, upload-time = "2026-08-28T10:01:09.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/18/87aefa427d191e6d3ab1447f1efc1cdcac86af1069239b133e8a0fd7f7c9/pydantic_core-2.46.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:337639ba62a11acde6ef3aeb08c8ea755f8ef1fe5e513356c0f36a2b0d7568b0", size = 1912713, upload-time = "2026-08-28T10:01:12.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/93/fd89e9ad49b1805ca94d24ce1088b7d305f05c35ffafcedb9819d03588a0/pydantic_core-2.46.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:413a717a410d0c817ef5b786a059415550b3794e1d0c2abffd9efb93a3d9f7b4", size = 2090926, upload-time = "2026-08-28T10:01:15.19Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/45/8e59dab6acf8d35f02f0a958980074f31038968bdb2c983fcae9d1efee03/pydantic_core-2.46.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e449def1945a462c464331254e5a44fca7c3b4f9aedf59ec2f50f8066dd8e25", size = 2131303, upload-time = "2026-08-28T10:01:17.937Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a5/e1d4dc5180dd887a9522efc1f8716b8692b7606b1d3273d7862eaf66be44/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:a445486499897b88a7d6c310c88ed64dd37b1b59bfd7ae9107490bbb362f47d6", size = 2145128, upload-time = "2026-08-28T10:01:20.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/ad493864a7fb21c0c4df98f965e2db430cb25a9d7369b5778d5016c09fd9/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:2d330aaba8621b1edcec8ae2c4050f63b84ccf6d98723a8f212e9684713abf0e", size = 2294560, upload-time = "2026-08-28T10:01:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8e/b41c84c913f29973a268e6c2b5bbf13c95adb9956c126d10da11ba3b2bef/pydantic_core-2.46.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:b6acfb46a814762367fb7ba0828b0a17d441b92ce249a0e007474c9072662dda", size = 2317531, upload-time = "2026-08-28T10:01:26.334Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1d/068464f23075f66a8f1b806935e9cd9363ee446636ea70d2c22ee8659dbf/pydantic_core-2.46.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d0a24b40877af2de4950252be9d21eaf7fb07660f3c2cae1f56c6b599ada5266", size = 2140686, upload-time = "2026-08-28T10:01:28.947Z" },
 ]
 
 [[package]]
 name = "pydantic-settings"
-version = "2.1.0"
+version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/10/664e41fd884d8cd3fa8bcd75a537bd82f540b19d7c0d1ff17eef69a2ffa8/pydantic_settings-2.1.0.tar.gz", hash = "sha256:26b1492e0a24755626ac5e6d715e9077ab7ad4fb5f19a8b7ed7011d52f36141c", size = 31824, upload-time = "2023-11-14T13:06:31.22Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/c9/8042368e9a1e6e229b5ec5d88449441a3ee8f8afe09988faeb190af30248/pydantic_settings-2.1.0-py3-none-any.whl", hash = "sha256:7621c0cb5d90d1140d2f0ef557bdf03573aac7035948109adf2574770b77605a", size = 11685, upload-time = "2023-11-14T13:06:30.129Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
 ]
 
 [[package]]
@@ -1958,6 +2109,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -2080,11 +2245,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.6"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/23/abcfad10c3348cb6358400f8adbc21b523bbc6c954494fd0974428068672/python_multipart-0.0.6.tar.gz", hash = "sha256:e9925a80bb668529f1b67c7fdb0a5dacdd7cbfc6fb0bff3ea443fe22bdd62132", size = 31024, upload-time = "2023-02-27T16:40:10.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/ff/b1e11d8bffb5e0e1b6d27f402eeedbeb9be6df2cdbc09356a1ae49806dbf/python_multipart-0.0.6-py3-none-any.whl", hash = "sha256:ee698bab5ef148b0a760751c261902cd096e57e10558e11aca17646b74ee1c18", size = 45711, upload-time = "2023-02-27T16:40:14.113Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -2094,6 +2259,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -2117,6 +2304,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/78/77b40157b6cb5f2d3d31a3d9b2efd1ba3505371f76730d267e8b32cf4b7f/PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4", size = 712604, upload-time = "2023-08-28T18:43:30.206Z" },
     { url = "https://files.pythonhosted.org/packages/2e/97/3e0e089ee85e840f4b15bfa00e4e63d84a3691ababbfea92d6f820ea6f21/PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54", size = 126098, upload-time = "2023-08-28T18:43:31.835Z" },
     { url = "https://files.pythonhosted.org/packages/2b/9f/fbade56564ad486809c27b322d0f7e6a89c01f6b4fe208402e90d4443a99/PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df", size = 138675, upload-time = "2023-08-28T18:43:33.613Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -2242,6 +2443,129 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143, upload-time = "2026-02-01T16:20:47.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69", size = 309963, upload-time = "2026-02-01T16:20:46.078Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/1f/a2dca5ffdbf1d475ffc4e80e4d5d720ff3a00f691795910116960ee12511/rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7", size = 342174, upload-time = "2026-06-30T07:14:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/dc/323d08583c0832911768663d1944f0107fcd4088704858d84b5e06d105a0/rpds_py-2026.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db08f45aecde626498fb3df07bcf6d2ec040af42e859a4f5040d79c200342911", size = 345513, upload-time = "2026-06-30T07:14:56.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2a/e31989834d18d2f26ec1d2774c5b1eb3331df4ea8ada525175294c94b48a/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acc992ab27b15f852c76755eb2ab7dce86585ddadba6fa5946e58556088845b4", size = 373783, upload-time = "2026-06-30T07:14:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/fe/e80107ee3639585c9941c17d6a42cd65325022f656c023191fce78c324c8/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f88d653e7b3b779d71ae7454e20dcc9b6bae903f33c269db9f2be41bda3f261", size = 378316, upload-time = "2026-06-30T07:14:59.077Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/81e3adf81acfb6fa694de2a6e4e7d8863121e3e0799e0a7725e6cf5679c4/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e52655eaf81e32593abedaa4bfe33170c8cfedf3365ed9be6e11e07f148f0278", size = 499423, upload-time = "2026-06-30T07:15:00.488Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/41263969df0ce3d9af2a96d5005a288200af1989aed3354bfceb5fc0b21f/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dfcc8b909769d19db55c7cc9541eb64b9b774b1057ffffb4f1048070475bb9f9", size = 386077, upload-time = "2026-06-30T07:15:01.911Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/7e98f468bd50346faff5b10e5297374b443bfdddacc8e9fbc65984539597/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c1255b302953c86a486b81d330d5ee1d5bd937691ce271b6be0ef0e299eaab7", size = 371315, upload-time = "2026-06-30T07:15:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3c/2b973b4d371906a134b03decfea7f5d9835a2c6d263454392e15b64b5b18/rpds_py-2026.6.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8d2294a31386bfa251d8c8a39472beee17db67d4f1a6eabea665d35c9a4461c3", size = 383502, upload-time = "2026-06-30T07:15:04.627Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2a/12e2799500af0a307bca76b63361c51f9fe479223561489c29eea1f2ee41/rpds_py-2026.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f8f23ead891a3b762f35ab3b04623da7056545b48aa60d59957e6789914545da", size = 402673, upload-time = "2026-06-30T07:15:05.856Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e3/21e5872d165fe08be4f229e3d5ee9d90019c0bf0e5538de60dbd54009450/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:421aba32367055614287a4292b6a17f1939c9452299f7a0209c117e990b646d4", size = 549964, upload-time = "2026-06-30T07:15:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d0/5ee0fe36844297de8123bee27bc12078c1a7416ad9f1b8a8ca18d6b0c0ac/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1e5822dfc2f0d4ab7e745eaa6d85945069329beeccef965af3f3bb26058fcab6", size = 615446, upload-time = "2026-06-30T07:15:08.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/80/1ea5873cb683f2fbe5f21b23ea1f6d179ead19f3c5b249b7eb5dca568ef2/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83e35b57523816c8613fd0776b40cd8bb9f596b37ddd2692eb4a6bb5ab2f8c93", size = 576975, upload-time = "2026-06-30T07:15:09.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e1/90ef639217a5ddb15b7f4f61b1c33911fd044ad03c311bafdd2bcab85582/rpds_py-2026.6.3-cp311-cp311-win32.whl", hash = "sha256:de3eceba0b683bcbb1ab93da016d0270df1f9ae7be716b40214c5dafac6ea45a", size = 204453, upload-time = "2026-06-30T07:15:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/b7a1695d7af36f521fb11e80d6d3adbd744f73b921859bd3c2a2c0dc706f/rpds_py-2026.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:2c54a076ca4d370980ab57bc0e31df57bbe8d41340436a90ef8b1219a3cbb127", size = 223219, upload-time = "2026-06-30T07:15:12.476Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a2/145afacf796e4506062825941176ad9445c2dcf2b3b6a1f13d3030a15e19/rpds_py-2026.6.3-cp311-cp311-win_arm64.whl", hash = "sha256:168c733a7112e071bb7a66460e667edfcff06c017a3c523f7a8a8e08d0140804", size = 219137, upload-time = "2026-06-30T07:15:13.631Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/f0d19ac587fd0e4ab6b72cda355e9c5a6166b01ef7e064e437aef8eb9fef/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4cf2d36a2357e4d07bb5a4f98801265327b48256867816cfd2ceb001e9754a8f", size = 349791, upload-time = "2026-06-30T07:17:33.315Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c7/1d49d204c9fd2ee6c537601dc4c1ba921e03363ca576bfab94a00254ac9a/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:30c6dc199b24a5e3e81d50da0f00858c5bbdb2617a750395687f4339c5818171", size = 352842, upload-time = "2026-06-30T07:17:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e5/c0b5dc93cd0d4c06ce1f438907649514e2ea077bcd911e3154a51e96c38e/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9891e594296ab9dada6551c8e7b387b2721f27a67eecd528412e8906247a7b90", size = 382094, upload-time = "2026-06-30T07:17:36.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/54/ec0e907b4ca8d541112db352409bd15f871c9b243e0c92c9b5a46ae96f01/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c2dc92304aa48a4a60443b548bb12f12e119d4b72f314015e67b9e1be97fca", size = 388662, upload-time = "2026-06-30T07:17:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f4/921c22a4fd0f1c1ac13a3996ffbf0aa67951e2c8ad0d1d9574938a2932e8/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:127e08c0642d880cf32ca47ec2a4a77b901f7e2dd1ad9762adb13955d72ffcc9", size = 504896, upload-time = "2026-06-30T07:17:39.689Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1b/a114b972cefa1ab1cdb3c7bb177cd3844a12826c507c722d3a73516dbbaf/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8bb68f03f395eb793220b45c097bd4d8c32944393da0fad8b999efac0868fc8c", size = 391545, upload-time = "2026-06-30T07:17:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/98/af9b3db77d47fcbe6c8c1f36e2c2147ec70292819e99c325f871584a1c11/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3450b693fde92133e9f51060568a4c31fcca76d5e53bbd611e689ca446517e9", size = 380059, upload-time = "2026-06-30T07:17:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ba/0efd8668b97c1d26a61566386c636a7a7a09829e474fdf807caa15a2c844/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:5e8d07bddee435a2ff6f1920e18feff28d0bc4533e42f4bf6927fbd073312c41", size = 393235, upload-time = "2026-06-30T07:17:44.637Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/8c139ee9690f73b0829f32647de6f40d826f8f443af6fa72644f96351aac/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a83ae6c67b7676b9878378547ca8e93ed77a580037bcbcd1d32f739e1e6089c", size = 413008, upload-time = "2026-06-30T07:17:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
+    { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
 ]
 
 [[package]]
@@ -2409,15 +2733,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
 name = "soupsieve"
 version = "2.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2472,14 +2787,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.27.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/68/559bed5484e746f1ab2ebbe22312f2c25ec62e4b534916d41a8c21147bf8/starlette-0.27.0.tar.gz", hash = "sha256:6a6b0d042acb8d469a01eba54e9cda6cbd24ac602c4cd016723117d6a7e73b75", size = 51394, upload-time = "2023-05-16T10:59:56.286Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/f8/e2cca22387965584a409795913b774235752be4176d276714e15e1a58884/starlette-0.27.0-py3-none-any.whl", hash = "sha256:918416370e846586541235ccd38a474c08b80443ed31c578a418e2209b3eef91", size = 66978, upload-time = "2023-05-16T10:59:53.927Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]
@@ -2497,6 +2813,7 @@ dependencies = [
     { name = "ffmpeg-python" },
     { name = "greenlet" },
     { name = "huggingface-hub" },
+    { name = "mcp" },
     { name = "numpy" },
     { name = "onnx" },
     { name = "onnx-clip" },
@@ -2545,11 +2862,12 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "cryptography", specifier = ">=49.0.0" },
     { name = "ddgs", specifier = ">=8.0" },
-    { name = "fastapi", specifier = "==0.104.1" },
+    { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "ffmpeg-python", specifier = "==0.2.0" },
     { name = "greenlet", specifier = ">=3.0.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "huggingface-hub" },
+    { name = "mcp", specifier = ">=1.26,<2" },
     { name = "numpy", specifier = ">=1.26.2" },
     { name = "onnx", specifier = "<1.18" },
     { name = "onnx-clip" },
@@ -2559,13 +2877,13 @@ requires-dist = [
     { name = "piexif", specifier = "==1.1.3" },
     { name = "pillow", specifier = ">=10.2.0" },
     { name = "psutil", specifier = ">=5.9" },
-    { name = "pydantic", specifier = "==2.5.0" },
-    { name = "pydantic-settings", specifier = "==2.1.0" },
+    { name = "pydantic", specifier = ">=2.11,<3" },
+    { name = "pydantic-settings", specifier = ">=2.5.2,<3" },
     { name = "pypdfium2", specifier = ">=4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "python-frontmatter", specifier = ">=1.0.0" },
-    { name = "python-multipart", specifier = "==0.0.6" },
+    { name = "python-multipart", specifier = ">=0.0.9,<1" },
     { name = "pyyaml", specifier = "==6.0.1" },
     { name = "rich", specifier = ">=14.3.2" },
     { name = "ruamel-yaml", specifier = ">=0.18.0" },
@@ -2578,7 +2896,7 @@ requires-dist = [
     { name = "strip-markdown", specifier = ">=1.3" },
     { name = "structlog" },
     { name = "trafilatura", specifier = ">=2.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = "==0.24.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.31.1,<1" },
     { name = "weasyprint", specifier = ">=62.0" },
     { name = "websockets", specifier = "==12.0" },
 ]
@@ -2716,6 +3034,18 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2747,15 +3077,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.24.0"
+version = "0.50.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/c9/dc0b3b6f944271d5f71564c2db08a1879a384cda7100f6f2f71b4ec9b751/uvicorn-0.24.0.tar.gz", hash = "sha256:368d5d81520a51be96431845169c225d771c9dd22a58613e1a181e6c4512ac33", size = 40092, upload-time = "2023-11-04T19:31:11.834Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/bb/88735238d7ead151c28d5432551170f17746c70c257aa66e8d7e64eca7a3/uvicorn-0.50.1.tar.gz", hash = "sha256:ccb3061887829fd8471cfa6fc65b2594689342ee00792e5d257d34871755b09f", size = 93722, upload-time = "2026-07-06T07:52:25.238Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/0c/a9b90a856bbdd75bf71a1dd191af1e9c9ac8a272ed337f7200950c3d3dd4/uvicorn-0.24.0-py3-none-any.whl", hash = "sha256:3d19f13dfd2c2af1bfe34dd0f7155118ce689425fdf931177abe832ca44b8a04", size = 59609, upload-time = "2023-11-04T19:31:09.321Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/59/02c7859295b001e77b8079fc9df9f8161b7c872cbf7ea8dab70cf51d61f1/uvicorn-0.50.1-py3-none-any.whl", hash = "sha256:8139bce59602f55d497c9ed77af3117b0b5fa033e3e887193fa00a5968c38c57", size = 72843, upload-time = "2026-07-06T07:52:23.62Z" },
 ]
 
 [package.optional-dependencies]

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,0 +1,84 @@
+# MCP server
+
+Stimma exposes an authenticated, profile-bound MCP endpoint through the existing backend and a local stdio bridge through `stimma mcp`. The server is disabled by default. Enable it and create a connection in the profile’s **Settings → MCP** section.
+
+## Transports and setup
+
+The native endpoint is `/mcp/profiles/{profile_id}`. It implements Streamable HTTP using the official Python MCP SDK. Each request carries `Authorization: Bearer <connection credential>`. Credentials are created through the owner-facing settings API; the server stores their hashes, installation identity and originating profile. MCP requests cannot select another profile through REST headers or query parameters.
+
+The bridge runs on the assistant’s machine:
+
+```sh
+stimma mcp install connection.stimma-mcp.json
+stimma mcp bridge connection-alias
+```
+
+The installer prints an `mcpServers` entry and stores the connection credential in a separate file with mode `0600`. Its argument is a downloaded connection file, not the profile PIN. The bridge requires the Stimma CLI and its Python backend dependencies. It opens authenticated HTTP sessions as needed; transport reconnections do not create new access grants.
+
+The bridge adds `media_upload` and `media_download`. Upload paths and downloaded result paths belong to the assistant’s machine. Native clients can implement the same authenticated HTTP transfer endpoints. A tool-only HTTP client can use workspace operations and inline previews but needs a transfer integration for full files.
+
+## Access and scope
+
+A connection authenticates one configured client on one profile. `workspace_get` and tool discovery work while locked. `access_open` accepts the existing profile PIN; profiles without a PIN can call it without an argument. PIN failures are serialized per profile and temporarily delay further attempts. PIN input and rejected validation values are omitted from MCP logs and error responses.
+
+Unlock grants are in memory, keyed by profile and configured client. They survive a bridge reconnect, expire after the profile’s idle timeout and disappear when the backend restarts. Chats using the same credential share the grant. Job polling does not extend it. An accepted task can finish after idle expiry, but reading its results or extending it requires an unlocked connection.
+
+Explicit locking, disconnecting, disabling MCP and PIN changes revoke external work. Cancellation cannot undo an operation already accepted by a provider. Desktop input into a delegated chat takes control and invalidates stale MCP continuations. References are signed and bind an entity kind, profile and database identity; a numeric identifier from another profile is never a valid substitute.
+
+Profile context also scopes active chat execution identifiers, pending tool permission identifiers and custom-tool catalogs. These are shared runtime components, so their scoping applies to desktop and MCP execution alike.
+
+## Operation surface
+
+Tool schemas are available through `tools/list`. Families use an `action` discriminant and action-specific schemas. `operations.py` explicitly selects existing domain functions and derives their typed inputs, then removes private configuration and filesystem fields and replaces entity IDs with signed references. This is a curated adapter, not arbitrary REST dispatch.
+
+| Surface | Purpose |
+| --- | --- |
+| `assets_query`, `assets_get`, `assets_facets`, `entities_search` | Browser filtering, inspection, counts and named-entity search |
+| `catalog_get`, `assets_select`, `selections_get` | Catalog discovery and stable, paginated selections with exact revision references |
+| `lineage_get`, `revisions_list`, `revisions_restore`, `contextual_media_get` | Provenance, saved revisions and contextual media |
+| Board, project, saved-view, preset, marker and tag families | Workspace organization through existing domain behavior |
+| Container families | Membership, promotion, creation and explosion |
+| `tools_search`, `tools_inspect`, `tools_options`, `tools_run` | Provider discovery and exact execution, including batches and sequential chains |
+| `agent_start`, `agent_continue` | Creative delegation in an ordinary Stimma chat |
+| `flows_get`, `flows_update`, `flows_run`, custom-tool families | Flow inspection/editing, one-shot execution and frozen tool management |
+| `content_update` | Saved raster transforms and SVG, Markdown or layout documents, with revision conflict guards |
+| `jobs_get`, `jobs_cancel`, `jobs_retry`, `interaction_respond` | Progress, cancellation, known-failure retries and exact-question responses |
+| `media_read`, `media_export` | Bounded previews and private original/bundle delivery |
+| `ui_context_get`, `ui_open` | Explicitly shared selection snapshots and UI route handoff |
+| `assets_delete_permanently`, `share_publish` | Explicit irreversible deletion and public sharing |
+
+`tools_run` calls the same SDK dispatch and permission gate used by the agent, without an LLM planning turn. Media inputs and schema versions are checked before acceptance. Batches retain per-item results. Chains can bind the previous saved media output to a declared media input. The server does not infer an output binding from an arbitrary parameter name.
+
+`agent_start` records the brief, reference roles, selected skills and deliverables in a normal chat. It reuses the existing agent, project context, model resolution and permissions. Permission questions are relayed to the connected assistant, which is trusted to obtain the human’s answer. Responses apply once and cannot change persistent permission policy through MCP arguments.
+
+`flows_run` uses the existing one-shot Flow runner with its runtime safeguards. Human selection callbacks wait for an explicit response instead of automatically choosing a candidate. This endpoint executes a separate run; it does not take over a Flow already running in the editor.
+
+There is no separate MCP budget, cumulative spend allocation or renewal protocol. Existing agent/runtime safeguards, tool permissions and cancellation remain in effect.
+
+## Receipts and recovery
+
+`mcp_operations` stores durable task acceptance, mutation receipts and selection snapshots. Synchronous database mutations use a transaction that commits the change and its receipt together. Request identity includes the configured client, operation and request key. Reusing a key with changed input returns `request_key_conflict`.
+
+Long-running or filesystem-affecting operations return a durable job before execution. Retrying acceptance retrieves that job rather than launching it again. The job links its ordinary chat, controller version, visible events and retained result manifest. Follow-ups and question responses require the current controller version and their own retry key.
+
+Work whose backend execution disappears is marked interrupted when recovered. Unknown provider outcomes are retained and excluded from automatic retries. A batch retry selects only explicitly failed items; it preserves successful outputs. No operation receipt is a promise that an external provider supports transactional rollback or exactly-once billing.
+
+Stable selection snapshots expire after 24 hours and record Asset, revision and Media references. Desktop context snapshots are separate: the user chooses **Share selection with connected assistants** from the media context menu, and the snapshot expires after ten minutes. Ordinary desktop selection changes do not expose ambient UI state.
+
+## Transfers
+
+Uploads enter the existing upload and Asset services and never select a server destination directory. Download handles bind the connection and current unlock grant, expire after fifteen minutes and stop working after relocking. Directory media is delivered as a complete ZIP bundle, with symlinks rejected. Downloads support byte ranges and include a SHA-256 checksum that the bridge verifies before completing its local file.
+
+Inline image previews are bounded to 1024 pixels on the longest edge. Small SVG, Markdown, text and JSON documents can be returned as text. Other formats use original-file delivery. `ui_open` returns a relative route and profile ID; host integrations must honor both and decide how to navigate.
+
+## Validation
+
+Run from the repository root:
+
+```sh
+tools/stimma lint backend
+tools/stimma test backend
+tools/stimma test acceptance
+```
+
+`backend/tests/test_mcp_server.py` covers native MCP discovery, real stdio bridge upload/download, credential and profile boundaries, idle expiry, PIN redaction, atomic retries, interrupted jobs, saved-edit conflicts, stable selections, direct batch recovery, Flow execution and desktop takeover. The acceptance lane exercises the existing application with fake providers in an isolated sandbox.

--- a/frontend/acceptance/tests/mcp-settings.spec.ts
+++ b/frontend/acceptance/tests/mcp-settings.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '../helpers/testbed';
+import { waitForShell } from '../helpers/app';
+
+test('MCP connection setup downloads a profile-bound credential and supports disconnect', async ({ page }, testInfo) => {
+  await page.addLocatorHandler(page.getByTestId('readiness-dismiss'), async dismiss => { await dismiss.click(); });
+  await page.goto('/browse');
+  await waitForShell(page);
+  await page.getByRole('button', { name: 'Settings', exact: true }).click();
+  await page.getByRole('button', { name: 'MCP', exact: true }).click();
+  const enabled = page.getByRole('checkbox', { name: 'Enable MCP for this profile' });
+  await enabled.check();
+  await expect(page.getByRole('button', { name: 'Download connection file' })).toBeVisible();
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download connection file' }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/\.stimma-mcp\.json$/);
+  const stream = await download.createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream!) chunks.push(Buffer.from(chunk));
+  const connection = JSON.parse(Buffer.concat(chunks).toString());
+  expect(connection.endpoint).toContain(`/mcp/profiles/${connection.profile_id}`);
+  expect(connection.credential.length).toBeGreaterThanOrEqual(32);
+  expect(connection).not.toHaveProperty('pin');
+  await expect(page.getByText(/stimma mcp install/)).toBeVisible();
+  await page.getByRole('button', { name: 'Lock external access', exact: true }).click();
+  await page.screenshot({ path: testInfo.outputPath('mcp-settings.png') });
+  await page.getByRole('button', { name: 'Disconnect', exact: true }).click();
+  await expect(page.getByText('No assistants connected yet.')).toBeVisible();
+  await enabled.uncheck();
+});

--- a/frontend/src/components/media/MediaContextMenu.vue
+++ b/frontend/src/components/media/MediaContextMenu.vue
@@ -75,6 +75,10 @@
 
       <!-- Normal View Actions -->
       <template v-else>
+        <button v-if="mcpEnabled && targetAssetIds.length && targetAssetIds.length <= 200"
+          class="w-full px-3 py-2 text-left text-xs text-content hover:bg-overlay-subtle"
+          @click="shareMcpSelection">Share selection with connected assistants</button>
+        <p v-if="mcpShareStatus" role="status" class="px-3 py-2 text-xs text-content-secondary">{{ mcpShareStatus }}</p>
         <!-- Bare Media (for example a grid cell or chat working result) can be kept explicitly. -->
         <button
           v-if="targetAssetIds.length === 0 && targetMediaIds.length > 0"
@@ -919,6 +923,21 @@ interface GenerateMoreTool {
 const router = useRouter()
 const { tabs: workspaceTabs } = useWorkspaceTabs()
 const contextMenu = useMediaContextMenu()
+const mcpEnabled = ref(false)
+const mcpShareStatus = ref('')
+watch(() => contextMenu.state.value.visible, async (visible) => {
+  if (!visible) return
+  mcpShareStatus.value = ''
+  mcpEnabled.value = false
+  try { mcpEnabled.value = (await axios.get('/api/mcp/settings')).data.enabled }
+  catch { /* MCP stays unavailable when settings cannot be read. */ }
+})
+async function shareMcpSelection() {
+  try {
+    await axios.post('/api/mcp/context', { asset_ids: targetAssetIds.value })
+    mcpShareStatus.value = 'Selection shared for 10 minutes.'
+  } catch { mcpShareStatus.value = 'Could not share this selection.' }
+}
 const { printAssetDetail, printContactSheet } = usePrint()
 const { deleteMedia, restoreFromTrash, permanentlyDeleteMedia, getMediaFileUrl, getMediaItem, getMediaFaces, getMarkers, addMarkerToMedia, removeMarkerFromMedia, downloadMedia, bulkDeleteMedia, bulkRestoreFromTrash, bulkPermanentlyDelete, bulkMarkerOperation, createSetFromMedia, getThumbnailUrl, getBoards, createBoard, addMediaToBoard, removeMediaFromProject } = useMediaApi()
 const {

--- a/frontend/src/components/settings/SettingsModal.vue
+++ b/frontend/src/components/settings/SettingsModal.vue
@@ -141,6 +141,10 @@
                 />
               </template>
 
+              <template v-else-if="activeSection === 'mcp'">
+                <McpSection :key="currentProfileId" />
+              </template>
+
               <!-- Agent Section -->
               <template v-else-if="activeSection === 'agent'">
                 <AgentSection />
@@ -215,6 +219,7 @@ import AIServicesSection from './sections/AIServicesSection.vue'
 import ModelPreferencesSection from './sections/ModelPreferencesSection.vue'
 import DeveloperSection from './sections/DeveloperSection.vue'
 import AgentSection from './sections/AgentSection.vue'
+import McpSection from './sections/McpSection.vue'
 import WildcardsSection from './sections/WildcardsSection.vue'
 import PinEntryModal from '../PinEntryModal.vue'
 import Modal from '../ui/Modal.vue'

--- a/frontend/src/components/settings/SettingsSidebar.vue
+++ b/frontend/src/components/settings/SettingsSidebar.vue
@@ -264,6 +264,7 @@ const profileSections = [
   { id: 'markers', label: 'Markers', icon: TagIcon },
   { id: 'wildcards', label: 'Prompt Variables', icon: WildcardIcon },
   { id: 'agent', label: 'Agent', icon: SparklesIcon },
+  { id: 'mcp', label: 'MCP', icon: ServerIcon },
 ]
 
 // Global settings (applies to all profiles)

--- a/frontend/src/components/settings/sections/McpSection.vue
+++ b/frontend/src/components/settings/sections/McpSection.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="space-y-8">
+    <div>
+      <h3 class="text-xs font-semibold text-content-secondary">MCP</h3>
+      <p class="mt-2 text-sm leading-relaxed text-content-tertiary">
+        Let a connected assistant work with this profile’s library, tools, Flows and agent.
+        Stimma must be running for the connection to work.
+      </p>
+    </div>
+    <p v-if="error" role="alert" class="text-sm text-red-400">{{ error }}</p>
+    <label class="flex items-center justify-between gap-4 text-sm text-content">
+      <span>Enable MCP for this profile</span>
+      <input type="checkbox" :checked="state.enabled" :disabled="busy" class="h-4 w-4 accent-accent" @change="setEnabled($event.target.checked)" />
+    </label>
+    <template v-if="state.enabled">
+      <div class="space-y-3">
+        <h4 class="text-xs font-semibold text-content-secondary">Connect an assistant</h4>
+        <p class="text-sm text-content-tertiary">Download a connection file, then install it with the Stimma CLI. Each assistant gets its own connection.</p>
+        <Button :disabled="busy" @click="connect">Download connection file</Button>
+        <p v-if="installCommand" class="text-xs text-content-tertiary">Run this command with the downloaded file:</p>
+        <pre v-if="installCommand" class="overflow-x-auto rounded-md bg-overlay-subtle p-3 text-xs text-content">{{ installCommand }}</pre>
+        <p class="text-xs leading-relaxed text-content-tertiary">The installer prints the MCP configuration to add to your assistant. The connection file contains a private credential; keep it on your own machine.</p>
+      </div>
+      <div class="space-y-3">
+        <h4 class="text-xs font-semibold text-content-secondary">Unlocking</h4>
+        <p class="text-sm leading-relaxed text-content-tertiary">Give your existing profile PIN to the assistant in chat when it asks. A PIN shared with an assistant lets it unlock again until you change the PIN. Stimma does not save the PIN in its MCP logs, but it remains in your assistant’s chat history.</p>
+        <p class="text-sm leading-relaxed text-content-tertiary">Chats using the same configured connection share its unlock. It locks after {{ state.idle_timeout_minutes }} minutes without content activity. Locking the desktop window does not lock external access.</p>
+        <Button variant="secondary" :disabled="busy" @click="lockAll">Lock external access</Button>
+      </div>
+      <div>
+        <h4 class="mb-3 text-xs font-semibold text-content-secondary">Connections</h4>
+        <p v-if="!state.clients.length" class="text-sm text-content-tertiary">No assistants connected yet.</p>
+        <div class="divide-y divide-edge-subtle">
+          <div v-for="client in state.clients" :key="client.id" class="flex items-center justify-between gap-4 py-3">
+            <div>
+              <p class="text-sm text-content">{{ client.name }}</p>
+              <p class="mt-1 text-xs text-content-tertiary">{{ client.unlocked ? 'Unlocked' : 'Locked' }}</p>
+            </div>
+            <Button variant="secondary" :disabled="busy" @click="disconnect(client.id)">Disconnect</Button>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, onUnmounted, ref } from 'vue'
+import axios from 'axios'
+import { getApiBase } from '../../../apiConfig'
+import Button from '../../ui/Button.vue'
+const state = ref({ enabled: false, clients: [], idle_timeout_minutes: 30 })
+const error = ref('')
+const busy = ref(false)
+const installCommand = ref('')
+let timer
+async function refresh() {
+  try { state.value = (await axios.get(`${getApiBase()}/mcp/settings`)).data }
+  catch { error.value = 'Could not load MCP settings.' }
+}
+async function perform(fn) {
+  busy.value = true
+  error.value = ''
+  try { await fn(); await refresh() }
+  catch { error.value = 'Could not update this connection. Check that Stimma is running.' }
+  finally { busy.value = false }
+}
+function setEnabled(enabled) { return perform(() => axios.put(`${getApiBase()}/mcp/settings`, { enabled })) }
+function lockAll() { return perform(() => axios.post(`${getApiBase()}/mcp/lock`)) }
+function disconnect(id) { return perform(() => axios.delete(`${getApiBase()}/mcp/clients/${id}`)) }
+function connect() {
+  return perform(async () => {
+    const { data } = await axios.post(`${getApiBase()}/mcp/clients`, { name: 'Assistant' })
+    const filename = `${data.connection.alias}.stimma-mcp.json`
+    const url = URL.createObjectURL(new Blob([JSON.stringify(data.connection, null, 2)], { type: 'application/json' }))
+    const link = document.createElement('a')
+    link.href = url
+    link.download = filename
+    link.click()
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
+    installCommand.value = `stimma mcp install "${filename}"`
+  })
+}
+onMounted(() => { refresh(); timer = setInterval(refresh, 10000) })
+onUnmounted(() => clearInterval(timer))
+</script>

--- a/scripts/generate-attribution.py
+++ b/scripts/generate-attribution.py
@@ -39,6 +39,7 @@ ATTRIBUTION = REPO_ROOT / "ATTRIBUTION.md"
 # embed full license text instead of an identifier). Verified against the
 # package's own LICENSE file or PyPI.
 PY_OVERRIDES = {
+    "pywin32": ("PSF-2.0 AND BSD-3-Clause AND (PSF-2.0 OR BSD-3-Clause) AND Python-2.0.1 AND MIT AND LGPL-2.1-or-later", "https://github.com/mhammond/pywin32"),
     "colorama": ("BSD-3-Clause", "https://github.com/tartley/colorama"),
     "win32-setctime": ("MIT", "https://github.com/Delgan/win32-setctime"),
     "pyreadline3": ("BSD-3-Clause", "https://github.com/pyreadline3/pyreadline3"),

--- a/tools/stimma.ts
+++ b/tools/stimma.ts
@@ -537,6 +537,7 @@ Flags:
                       cloud; app_branch stays 'dev' on the debug channel)
 
 Commands:
+  mcp install FILE | bridge ALIAS  Install or run a profile MCP connection
   dev frontend    Run Vite dev server with HMR (default port 9192)
   dev backend     Run Python backend with nodemon (default port 9191)
   dev backend2    Run Rust backend (default port 9191)
@@ -2217,6 +2218,10 @@ async function main(): Promise<void> {
   const rest = args.slice(2);
 
   switch (command) {
+    case "mcp": {
+      await run("uv", ["run", "--quiet", "python", "-m", "mcp_server.bridge", ...args.slice(1)], { cwd: join(repoRoot, "backend") });
+      break;
+    }
     case "headless": {
       await run("python3", [join(repoRoot, "tools", "headless.py"), ...args.slice(1)]);
       break;


### PR DESCRIPTION
Adds a profile-bound MCP server so a connected assistant can search and organize the workspace, execute known tools and Flows, and delegate creative work to the existing Stimma agent. Settings can enable MCP, create a connection file, lock external access and disconnect clients. The local `stimma mcp` bridge supplies stdio plus authenticated uploads and downloads.

The implementation includes:

- Credential and PIN access scoped to a configured client and profile, with shared reconnect-safe unlocks, idle expiry, revocation and redacted MCP logs.
- Typed workspace operations, signed entity references, stable selections, revision-guarded saved edits, and explicit temporary sharing of desktop selections.
- Atomic mutation receipts and durable job acceptance, retained batch results, exact-question responses, controller versions, cancellation and conservative recovery of unknown provider outcomes.
- Existing agent, SDK, Flow runner and spend/shell permissions. No separate MCP budgets or renewal protocol.
- Profile isolation for shared chat runtime state, permission gates and custom-tool catalogs; database migration and SDK-compatible dependency updates.

`docs/MCP_SERVER.md` documents the implementation and integration boundaries. The user guide is in https://github.com/stimma-ai/stimma-cloud/pull/1. The bridge requires the Stimma CLI on the assistant’s machine; direct HTTP clients need their own file-transfer integration. UI handoff returns a profile and route, and Flow execution uses the existing one-shot runner.

Validation:

- Full backend suite: passed in CI on the final commit. MCP integration suite: 24 passed locally.
- Browser acceptance: passed in CI on the final commit. Locally, 48 existing tests plus the new MCP settings test passed; 4 platform-specific tests skipped.
- Frontend production build and backend lint: passed.
- Real stdio-to-HTTP bridge test covers discovery, upload and verified download; integration tests cover separate profile databases, retry recovery, revision conflicts, a Flow awaiting an exact human selection, and temporary candidate previews that cannot be exported as saved results.
- Regenerated dependency attribution.

No release or deployment is included.
